### PR TITLE
Proactively install Node/Python on boot

### DIFF
--- a/src-tauri/npx
+++ b/src-tauri/npx
@@ -9,13 +9,14 @@
 # Copyright 2021 Square, Inc. All Rights Reserved.
 
 set -euo pipefail
-
-LOGFILE="/tmp/runebook_npx.log"
-> "$LOGFILE"
+LOGFILE="$HOME/Library/Logs/co.runebook/Tome.log"
+echo >> $LOGFILE
 
 log() {
     local LINE="$1"
-    echo "$(date +'%Y-%m-%d %H:%M:%S') :: $LINE" >> $LOGFILE
+    local DATE="$(date +'%Y-%m-%d')"
+    local TIME="$(date +'%H:%M:%S')"
+    echo "[$DATE][$TIME][hermit][DEBUG] $LINE" >> $LOGFILE
 }
 trap 'log "ERROR: Exiting w/ status: $?."' ERR
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -60,6 +60,9 @@ fn main() {
                 log::info!("deep link URLs: {:?}", event.urls());
             });
 
+            let handle = app.handle().clone();
+            tauri::async_runtime::spawn(mcp::bootstrap(handle));
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -7,7 +7,26 @@ use anyhow::Result;
 use rmcp::model::CallToolRequestParam;
 use rmcp::model::Tool;
 use server::McpServer;
+use tauri::path::BaseDirectory;
 use tauri::{AppHandle, Manager};
+use tokio::process::Command;
+
+// Install Python (uv/uvx) and Node (npm/npx), via Hermit.
+//
+pub async fn bootstrap(app: AppHandle) -> Result<()> {
+    let mut uvx = Command::new(app.path().resolve("uvx", BaseDirectory::Resource)?);
+    let uvx = uvx.arg("--help");
+    uvx.kill_on_drop(true);
+
+    let mut npx = Command::new(app.path().resolve("npx", BaseDirectory::Resource)?);
+    let npx = npx.arg("--help");
+    npx.kill_on_drop(true);
+
+    uvx.output().await?;
+    npx.output().await?;
+
+    Ok(())
+}
 
 // Start an MCP Server
 //

--- a/src-tauri/uvx
+++ b/src-tauri/uvx
@@ -9,13 +9,14 @@
 # Copyright 2021 Square, Inc. All Rights Reserved.
 
 set -euo pipefail
-
-LOGFILE="/tmp/runebook_uvx.log"
-> "$LOGFILE"
+LOGFILE="$HOME/Library/Logs/co.runebook/Tome.log"
+echo >> $LOGFILE
 
 log() {
     local LINE="$1"
-    echo "$(date +'%Y-%m-%d %H:%M:%S') :: $LINE" >> $LOGFILE
+    local DATE="$(date +'%Y-%m-%d')"
+    local TIME="$(date +'%H:%M:%S')"
+    echo "[$DATE][$TIME][hermit][DEBUG] $LINE" >> $LOGFILE
 }
 trap 'log "ERROR: Exiting w/ status: $?."' ERR
 


### PR DESCRIPTION
Instead of waiting for the first use of MCP to trigger a uvx/npx command, proactively installs them on boot, by calling `uvx|npx --help`.

This means, but the time the user goes to add an MCP server the deps needed to run it are available. Hopefully.