### PR TITLE
Fixes load error when model has been removed

### DIFF
--- a/src/components/Chat.svelte
+++ b/src/components/Chat.svelte
@@ -6,6 +6,7 @@
 	import { dispatch } from '$lib/dispatch';
 	import type { Role } from '$lib/llm';
 	import type { IMessage } from '$lib/models/message';
+	import Model from '$lib/models/model.svelte';
 	import Session, { type ISession } from '$lib/models/session';
 
 	interface Props {
@@ -129,7 +130,11 @@
 
 <Flex class="h-content w-full flex-col p-8 pb-0">
 	<!-- Chat Log -->
-	<div bind:this={content} class="bg-medium relative mb-8 h-full w-full overflow-auto px-2">
+	<div
+		bind:this={content}
+		class:opacity-25={!Model.exists(model)}
+		class="bg-medium relative mb-8 h-full w-full overflow-auto px-2"
+	>
 		{#each messages as message (message.id)}
 			<Flex class="mb-8 w-full flex-col items-start">
 				<!-- Svelte hack: ensure chat is always scrolled to the bottom when a new message is added -->
@@ -153,6 +158,7 @@
 		bind:this={input}
 		oninput={resize}
 		onkeydown={onChatInput}
+		disabled={!Model.exists(model)}
 		placeholder="Message..."
 		class="disabled:text-dark item bg-dark border-light focus:border-purple/15
         mb-8 h-auto w-full grow rounded-xl border p-3 pl-4 outline-0 transition duration-300"

--- a/src/lib/models/base.svelte.ts
+++ b/src/lib/models/base.svelte.ts
@@ -173,7 +173,13 @@ export default function Model<Interface extends Obj, Row extends Obj>(table: str
             });
         }
 
-        // Find the last record, by `id`
+        // Find the first record
+        //
+        static first(): Interface {
+            return repo[0];
+        }
+
+        // Find the last record
         //
         static last(): Interface {
             return repo[repo.length - 1];

--- a/src/lib/models/model.svelte.ts
+++ b/src/lib/models/model.svelte.ts
@@ -34,11 +34,23 @@ export default class Model {
         return repo.find(m => m.name == name) as IModel;
     }
 
+    static exists(name: string): boolean {
+        return this.find(name) !== undefined;
+    }
+
+    static first(): IModel {
+        return repo[0];
+    }
+
+    static last(): IModel {
+        return repo[repo.length - 1];
+    }
+
     static all(): IModel[] {
         return repo;
     }
 
     static supportsTools(model: IModel): boolean {
-        return model.capabilities?.includes('tools') == true;
+        return model && model.capabilities?.includes('tools') == true;
     }
 }

--- a/src/lib/models/session.ts
+++ b/src/lib/models/session.ts
@@ -4,10 +4,10 @@ import moment from "moment";
 import * as llm from '$lib/llm';
 import { getMCPTools } from '$lib/mcp';
 import App, { type IApp } from '$lib/models/app';
-import Model, { type ToSqlRow } from '$lib/models/base.svelte';
+import Base, { type ToSqlRow } from '$lib/models/base.svelte';
 import McpServer, { type IMcpServer } from "$lib/models/mcp-server";
 import Message, { type IMessage } from "$lib/models/message";
-import LLMModel from '$lib/models/model.svelte';
+import Model, { type IModel } from '$lib/models/model.svelte';
 
 export const DEFAULT_SUMMARY = 'Untitled';
 export interface ISession {
@@ -31,12 +31,12 @@ interface Row {
     modified: string;
 }
 
-export default class Session extends Model<ISession, Row>('sessions') {
+export default class Session extends Base<ISession, Row>('sessions') {
     static default(): ISession {
         return {
             summary: DEFAULT_SUMMARY,
             config: {
-                model: LLMModel.default().name,
+                model: Model.default().name,
                 enabledMcpServers: [],
             }
         }
@@ -53,9 +53,9 @@ export default class Session extends Model<ISession, Row>('sessions') {
     }
 
     static async tools(session: ISession): Promise<llm.Tool[]> {
-        const model = LLMModel.find(session.config.model);
+        const model = Model.find(session.config.model);
 
-        if (!LLMModel.supportsTools(model)) {
+        if (!Model.supportsTools(model)) {
             return [];
         }
 


### PR DESCRIPTION
When a model has been removed via Ollama directly, and a Session was using that model, the app wouldn't start as it was trying to load a model that no longer exists.

Shows a warning that the model is gone and disables the chat area, in that scenario.

<img width="1732" alt="image" src="https://github.com/user-attachments/assets/2a692b78-13bb-4783-867d-7a777b89384f" />