### PR TITLE
Adds Tool Calls to chat log + refactor

### DIFF
--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -114,5 +114,13 @@ UPDATE sessions SET config = json_insert(config, '$.temperature', 0.8);
             "#,
             kind: MigrationKind::Up,
         },
+        Migration {
+            version: 7,
+            description: "associate_tool_call_with_response",
+            sql: r#"
+ALTER TABLE messages ADD COLUMN response_id INTEGER REFERENCES messages(id);
+            "#,
+            kind: MigrationKind::Up,
+        },
     ]
 }

--- a/src/app.css
+++ b/src/app.css
@@ -7,6 +7,7 @@
     --color-purple: #bb9af7;
     --color-red: #ff757f;
     --color-green: #c3e88d;
+    --color-yellow: #ffc777;
 
     --border-color-light: #171717;
 

--- a/src/components/Message.svelte
+++ b/src/components/Message.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-
-	import Flex from '$components/Flex.svelte';
-	import Thought from '$components/Thought.svelte';
-	import markdown from '$lib/markdown';
+	import Assistant from '$components/Messages/Assistant.svelte';
+	import Tool from '$components/Messages/Tool.svelte';
+	import User from '$components/Messages/User.svelte';
 	import type { IMessage } from '$lib/models/message';
 
 	interface Props {
@@ -11,33 +9,12 @@
 	}
 
 	const { message }: Props = $props();
-
-	// Rounded css class.
-	let rounded = $state('rounded-full');
-
-	// svelte-ignore non_reactive_update
-	let ref: HTMLDivElement;
-
-	onMount(() => {
-		// If the message spans 2 or more lines, full rounded looks absurd.
-		if (ref?.clientHeight > 28) {
-			rounded = 'rounded-2xl';
-		}
-	});
 </script>
 
 {#if message.role == 'user'}
-	<Flex class={`bg-light self-end ${rounded} px-8 py-3`}>
-		<div bind:this={ref}>{message.content}</div>
-	</Flex>
-{:else}
-	{#if message.thought}
-		<Thought thought={message.thought} />
-	{/if}
-
-	<Flex class="text-medium w-full justify-between p-2 text-xs">
-		<p class="message markdown-body text-sm whitespace-normal">
-			{@html markdown.render(message.content)}
-		</p>
-	</Flex>
+	<User {message} />
+{:else if message.role == 'assistant' && message.content === '' && message.toolCalls.length}
+	<Tool {message} />
+{:else if message.role == 'assistant'}
+	<Assistant {message} />
 {/if}

--- a/src/components/Messages/Assistant.svelte
+++ b/src/components/Messages/Assistant.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import Flex from '$components/Flex.svelte';
+	import Thought from '$components/Messages/Thought.svelte';
+	import markdown from '$lib/markdown';
+	import type { IMessage } from '$lib/models/message';
+
+	interface Props {
+		message: IMessage;
+	}
+
+	const { message }: Props = $props();
+</script>
+
+{#if message.thought}
+	<Thought thought={message.thought} />
+{/if}
+
+<Flex class="text-medium mb-6 w-full justify-between p-2 text-xs">
+	<p class="message markdown-body text-sm whitespace-normal">
+		{@html markdown.render(message.content)}
+	</p>
+</Flex>

--- a/src/components/Messages/Thought.svelte
+++ b/src/components/Messages/Thought.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import Svg from '$components/Svg.svelte';
+
+	const { thought } = $props();
+
+	let isOpen = $state(false);
+	const rounded = $derived.by(() => (isOpen ? 'rounded-xl' : 'rounded-full'));
+
+	function toggle() {
+		isOpen = isOpen ? false : true;
+	}
+</script>
+
+<thought class={`text-medium border-light mb-4 ${rounded} border pr-2`}>
+	<button
+		onclick={() => toggle()}
+		class="flex w-full items-center gap-4 p-2 px-4 hover:cursor-pointer"
+	>
+		<Svg name="Lightbulb" class="h-6 w-6" />
+		Model Thoughts
+	</button>
+
+	{#if isOpen}
+		<p class="p-4 px-6 whitespace-pre-wrap">
+			{thought}
+		</p>
+	{/if}
+</thought>

--- a/src/components/Messages/Tool.svelte
+++ b/src/components/Messages/Tool.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import Flex from '$components/Flex.svelte';
+	import Svg from '$components/Svg.svelte';
+	import markdown from '$lib/markdown';
+	import Message, { type IMessage } from '$lib/models/message';
+
+	interface Props {
+		message: IMessage;
+	}
+
+	const { message }: Props = $props();
+	const response = $derived(Message.find(message.responseId as number));
+
+	let isOpen = $state(false);
+	let css = $derived.by(() => (isOpen ? 'rounded-xl w-full' : 'rounded-full'));
+
+	function toggle() {
+		isOpen = isOpen ? false : true;
+	}
+
+	function format(response: IMessage) {
+		try {
+			const json = JSON.parse(response.content);
+			const str = JSON.stringify(json, null, 4);
+			return '```json\n' + str + '\n```';
+		} catch {
+			return response.content;
+		}
+	}
+</script>
+
+{#each message.toolCalls as call, i (i)}
+	<Flex class={`border-light flex-col items-start ${css} mb-8 border p-2 px-3`}>
+		<Flex onclick={toggle} class="hover:cursor-pointer">
+			<Svg name="MCP" class="text-dark h-4 w-4" />
+
+			<Flex class="gap-2">
+				<p class="flex items-center px-3 py-1 text-sm">
+					<span class="text-yellow mr-4">{call.function.name}</span>
+
+					{#each Object.entries(call.function.arguments) as [name, value] (name)}
+						<span class="text-medium mr-1">{name}:</span>
+						<span class="text-light mr-4">{value}</span>
+					{/each}
+				</p>
+			</Flex>
+		</Flex>
+
+		{#if isOpen}
+			<div
+				class="border-light mt-4 mb-1 w-full overflow-auto rounded-md border p-2 px-4 whitespace-pre"
+			>
+				{@html markdown.render(format(response))}
+			</div>
+		{/if}
+	</Flex>
+{/each}

--- a/src/components/Messages/User.svelte
+++ b/src/components/Messages/User.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	import Flex from '$components/Flex.svelte';
+	import type { IMessage } from '$lib/models/message';
+
+	interface Props {
+		message: IMessage;
+	}
+
+	const MAX_HEIGHT_PER_LINE = 28;
+	const { message }: Props = $props();
+
+	let rounded = $state('rounded-full');
+	let ref: HTMLDivElement;
+
+	onMount(() => {
+		if (ref?.clientHeight > MAX_HEIGHT_PER_LINE) {
+			rounded = 'rounded-2xl';
+		}
+	});
+</script>
+
+<Flex class={`bg-light self-end ${rounded} mb-8 px-8 py-3`}>
+	<div bind:this={ref}>{message.content}</div>
+</Flex>

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -2,10 +2,11 @@
 import moment from "moment";
 
 export enum Level {
-    LOG = 'LOG',
-    INFO = 'INFO',
-    DEBUG = 'DEBUG',
-    ERROR = 'ERROR',
+    LOG = 'log',
+    INFO = 'info',
+    DEBUG = 'debug',
+    WARN = 'warn',
+    ERROR = 'error',
 }
 
 const colors = {
@@ -13,6 +14,7 @@ const colors = {
     blue: '#a9b1d6',
     yellow: '#ffc777',
     green: '#c3e88d',
+    orange: '#ff9e64',
     red: '#ff757f',
     purple: '#bb9af7',
     white: '#ffffff',
@@ -23,32 +25,51 @@ const levelColors = {
     [Level.LOG]: 'grey',
     [Level.INFO]: 'blue',
     [Level.DEBUG]: 'yellow',
+    [Level.WARN]: 'orange',
     [Level.ERROR]: 'red',
 };
 
-export function log(text: string, ...rest: any[]) {
-    console.log(...fmt(Level.LOG, text), ...rest);
+export function log(...args: any[]) {
+    _log(args, Level.LOG);
 };
 
-export function info(text: string, ...rest: any[]) {
-    console.info(...fmt(Level.INFO, text), ...rest);
+export function info(...args: any[]) {
+    _log(args, Level.INFO);
 };
 
-export function debug(text: string, ...rest: any[]) {
-    console.debug(...fmt(Level.DEBUG, text), ...rest);
+export function debug(...args: any[]) {
+    _log(args, Level.DEBUG);
 };
 
-export function error(text: string, ...rest: any[]) {
-    console.error(...fmt(Level.ERROR, text), ...rest);
+export function warn(...args: any[]) {
+    _log(args, Level.WARN);
 };
+
+export function error(...args: any[]) {
+    _log(args, Level.ERROR);
+};
+
+function _log(args: any[], level: Level) {
+    if (typeof args[0] !== 'string') {
+        console[level](
+            ...fmt(level, ""),
+            ...args,
+        )
+    } else {
+        console[level](
+            ...args.flatMap(arg => (
+                typeof arg === 'string' ? fmt(level, arg) : arg
+            ))
+        );
+    }
+}
 
 function fmt(level: Level, text: string): string[] {
     const now = moment();
     const date = now.format('YYYY-MM-DD');
     const time = now.format('hh:mm:ss');
     const lvl = levelColors[level];
-
-    return colorize(`[grey]${date}\t${time}\t\ttome\t[${lvl}]${level}\t\t[white]${text}`);
+    return colorize(`[grey]${date}\t${time}\t\ttome\t[${lvl}]${level.toUpperCase()}\t\t[white]${text}`);
 }
 
 function colorize(text: string): string[] {

--- a/src/lib/models/message.ts
+++ b/src/lib/models/message.ts
@@ -13,6 +13,7 @@ export interface IMessage {
     name: string;
     toolCalls: Record<string, any>[]; // eslint-disable-line
     sessionId?: number;
+    responseId?: number;
     created?: moment.Moment;
     modified?: moment.Moment;
 }
@@ -26,6 +27,7 @@ interface Row {
     name: string;
     tool_calls: string;
     session_id: number;
+    response_id?: number;
     created: string;
     modified: string;
 }
@@ -61,6 +63,7 @@ export default class Message extends Model<IMessage, Row>('messages') {
             name: row.name,
             toolCalls: JSON.parse(row.tool_calls),
             sessionId: row.session_id,
+            responseId: row.response_id,
             created: moment.utc(row.created),
             modified: moment.utc(row.modified),
         };
@@ -75,6 +78,7 @@ export default class Message extends Model<IMessage, Row>('messages') {
             name: message.name,
             tool_calls: JSON.stringify(message.toolCalls),
             session_id: message.sessionId as number,
+            response_id: message.responseId,
         }
     }
 }


### PR DESCRIPTION
Adds an MCP tool call notification to the chat log.

Also refactors the messages into individual components, based on their type (User, Assistant, Tool, Thought).

`messages` table gains a `response_id` foreign key to itself. Associates a tool call message to the tool response message.

---

Default:
<img width="1732" alt="image" src="https://github.com/user-attachments/assets/199a4ba6-6287-491d-a3d2-66e9a178d3f6" />

Opened:
<img width="1732" alt="image" src="https://github.com/user-attachments/assets/b868953b-36cd-48fe-bfe1-2417265fd2fc" />
