### PR TITLE
Convert MCP Install deep link to VSCode format

### DIFF
--- a/src-tauri/src/deeplink.rs
+++ b/src-tauri/src/deeplink.rs
@@ -2,36 +2,40 @@ use tauri::{Emitter, Url};
 
 use crate::APP_HANDLE;
 
-pub fn install_mcp_server(payload: String) {
+pub fn mcp_install(query: &str) {
     APP_HANDLE
         .get()
         .unwrap()
-        .emit("install-mcp-server", payload)
+        .emit("mcp/install", query)
         .unwrap();
 }
 
-pub fn handle(urls: Vec<Url>) -> Result<(), ()> {
+pub fn handle(urls: Vec<Url>) {
     if urls.is_empty() {
         log::warn!("User likely clicked an empty tome:// link?");
-        return Ok(());
+        return;
     }
 
-    let host = urls[0].host_str();
+    let url = urls[0].clone();
+    let host = url.host_str();
+
     match host {
-        Some("install-mcp-server") => {
-            if let Some(pair) = urls[0].query_pairs().find(|(k, _)| k == "payload") {
-                install_mcp_server(pair.1.to_string());
-            } else {
-                log::warn!("Missing `payload` query param");
-            }
+        Some("mcp") => {
+            handle_mcp(url);
         }
         Some(&_) => {
             log::warn!("Unknown runebook function for {:?}", host);
         }
         None => {
-            log::warn!("Malformed runebook link: missing host for {:?}", urls[0]);
+            log::warn!("Malformed runebook link: missing host for {:?}", url);
         }
     }
+}
 
-    Ok(())
+fn handle_mcp(url: Url) {
+    if url.path() == "/install" {
+        mcp_install(url.query().unwrap());
+    } else {
+        log::warn!("Unsupported MCP event: {}", url.path());
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -65,7 +65,7 @@ fn main() {
             configure_macos_window(&window);
 
             app.deep_link().on_open_url(|event| {
-                deeplink::handle(event.urls()).unwrap();
+                deeplink::handle(event.urls());
             });
 
             let handle = app.handle().clone();

--- a/src/lib/deeplinks.d.ts
+++ b/src/lib/deeplinks.d.ts
@@ -1,5 +1,6 @@
-export interface InstallMcpServerPayload {
+export interface VSCodeMcpInstallConfig {
+    name: string;
+    type: string;
     command: string;
     args: string[];
-    env: Record<string, string>;
 }

--- a/src/lib/deeplinks.ts
+++ b/src/lib/deeplinks.ts
@@ -1,16 +1,14 @@
 import { listen } from "@tauri-apps/api/event";
 import { goto } from "$app/navigation";
 
-import type { InstallMcpServerPayload } from '$lib/deeplinks.d';
-
 export * from '$lib/deeplinks.d';
 
 export enum DeepLinks {
-    InstallMcpServer = 'install-mcp-server',
+    InstallMcpServer = 'mcp/install',
 }
 
 export function setupDeeplinks() {
-    listen<InstallMcpServerPayload>(DeepLinks.InstallMcpServer, event => {
-        goto(`/mcp-servers/install?payload=${event.payload}`);
+    listen<string>(DeepLinks.InstallMcpServer, async (event) => {
+        goto(`/mcp-servers/install?config=${event.payload}`);
     });
 }

--- a/src/routes/mcp-servers/install/+page.svelte
+++ b/src/routes/mcp-servers/install/+page.svelte
@@ -6,14 +6,15 @@
 	import Flex from '$components/Flex.svelte';
 	import Layout from '$components/Layouts/Default.svelte';
 	import Modal from '$components/Modal.svelte';
-	import type { InstallMcpServerPayload } from '$lib/deeplinks';
+	import Svg from '$components/Svg.svelte';
+	import type { VSCodeMcpInstallConfig } from '$lib/deeplinks';
 	import McpServer from '$lib/models/mcp-server';
 
-	const payload = page.url.searchParams.get('payload') as string;
-	const cmd: InstallMcpServerPayload = JSON.parse(payload);
+	const payload = page.url.searchParams.get('config') as string;
+	const config: VSCodeMcpInstallConfig = JSON.parse(decodeURIComponent(payload));
 
 	async function install() {
-		const server = await McpServer.create(cmd);
+		const server = await McpServer.create(config);
 		goto(`/mcp-servers/${server.name}`);
 	}
 
@@ -24,42 +25,30 @@
 
 <Layout>
 	<Modal close={cancel}>
-		<Flex class="w-full flex-col items-start">
-			<h2 class="ml-2">Install {cmd.args[0]}?</h2>
+		{#if config.type !== 'stdio'}
+			<Flex class="text-red w-full">
+				<Svg name="Warning" class="mr-8 h-6 w-6" />
+				<p>Tome only supports <code>stdio</code> MCP servers</p>
+			</Flex>
+		{:else}
+			<Flex class="w-full flex-col items-start">
+				<h2 class="ml-2">Install {config.args[0]}?</h2>
 
-			<Flex class="border-light mt-4 w-full flex-col items-start rounded-md border">
-				<h3 class="text-medium p-2 pl-4 text-sm">Command</h3>
-				<Flex class="border-t-light w-full overflow-x-scroll border-t p-2 pl-4">
-					<code class="whitespace-nowrap">
-						{cmd.command}
-						{cmd.args.join(' ')}
-					</code>
+				<Flex class="border-light mt-4 w-full flex-col items-start rounded-md border">
+					<h3 class="text-medium p-2 pl-4 text-sm">Command</h3>
+					<Flex class="border-t-light w-full overflow-x-scroll border-t p-2 pl-4">
+						<code class="whitespace-nowrap">
+							{config.command}
+							{config.args.join(' ')}
+						</code>
+					</Flex>
+				</Flex>
+
+				<Flex class="mt-8 self-end">
+					<Button onclick={cancel} class="text-medium border-0">Cancel</Button>
+					<Button onclick={install} class="border-purple text-purple">Install</Button>
 				</Flex>
 			</Flex>
-
-			<Flex
-				class="border-light mt-4 w-full flex-col items-start
-                rounded-md border border-b-0"
-			>
-				<h3 class="text-medium p-2 pl-4 text-sm">ENV</h3>
-				<Flex
-					class="border-t-light grid w-full auto-cols-max
-                    auto-rows-max grid-cols-2 border-t text-sm"
-				>
-					{#each Object.entries(cmd.env) as [key, value] (key)}
-						<p
-							class="border-b-light border-r-light border-r border-b p-2 pl-4 uppercase"
-						>
-							{key}
-						</p>
-						<p class="border-b-light border-b p-2 pl-4">{value}</p>
-					{/each}
-				</Flex>
-			</Flex>
-			<Flex class="mt-8 self-end">
-				<Button onclick={cancel} class="text-medium border-0">Cancel</Button>
-				<Button onclick={install} class="border-purple text-purple">Install</Button>
-			</Flex>
-		</Flex>
+		{/if}
 	</Modal>
 </Layout>


### PR DESCRIPTION
Smithery currently only supports VSCode-style deep links. VSCode expects deeplinks in the format:

```
<scheme>://<resource>/<action>?<urlencoded_json_payload>
```

This change updates our MCP deeplink support to conform to that shape. This means Tome URLs will like the following, for example.

```
tome://mcp/install?%7B%22name%22%3A%22mcp-fetch%22%2C%22type%22%3A%22stdio%22%2C%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-server-fetch%22%5D%7D
```

This is kind of annoying since the query string isn't the normal key/value pairs you'd see in most URLs, but here we are.

We ignore `name` for now – we're retrieving this from the server itself on installation.

If we receive a link with a `type` of anything other than `stdio`, we show the following error modal:

<img width="1792" alt="image" src="https://github.com/user-attachments/assets/ec799490-af9b-4479-9fdd-a837075e9d4e" />