### PR TITLE
Fix yet another deeplink issue

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Tome"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/src/deeplink.rs
+++ b/src-tauri/src/deeplink.rs
@@ -12,30 +12,19 @@ pub fn mcp_install(query: &str) {
 
 pub fn handle(urls: Vec<Url>) {
     if urls.is_empty() {
-        log::warn!("User likely clicked an empty tome:// link?");
+        log::warn!("User likely clicked an empty tome: link?");
         return;
     }
 
     let url = urls[0].clone();
-    let host = url.host_str();
+    let path = url.path();
 
-    match host {
-        Some("mcp") => {
-            handle_mcp(url);
+    match path {
+        "mcp/install" => {
+            mcp_install(url.query().unwrap());
         }
-        Some(&_) => {
-            log::warn!("Unknown runebook function for {:?}", host);
+        _ => {
+            log::warn!("Unknown runebook function for {:?}", path);
         }
-        None => {
-            log::warn!("Malformed runebook link: missing host for {:?}", url);
-        }
-    }
-}
-
-fn handle_mcp(url: Url) {
-    if url.path() == "/install" {
-        mcp_install(url.query().unwrap());
-    } else {
-        log::warn!("Unsupported MCP event: {}", url.path());
     }
 }

--- a/src/routes/mcp-servers/install/+page.svelte
+++ b/src/routes/mcp-servers/install/+page.svelte
@@ -32,7 +32,7 @@
 			</Flex>
 		{:else}
 			<Flex class="w-full flex-col items-start">
-				<h2 class="ml-2">Install {config.args[0]}?</h2>
+				<h2 class="ml-2">Install {config.name}?</h2>
 
 				<Flex class="border-light mt-4 w-full flex-col items-start rounded-md border">
 					<h3 class="text-medium p-2 pl-4 text-sm">Command</h3>


### PR DESCRIPTION
VSCode breaks URLs more. It's `tome:` not `tome://`.