### PR TITLE
Ollama on Windows CORS fix + misc. fixes

### DIFF
--- a/src-tauri/src/http.rs
+++ b/src-tauri/src/http.rs
@@ -15,6 +15,7 @@ enum HttpMethod {
 
 #[derive(Deserialize)]
 pub struct ProxyOptions {
+    #[serde(default = "default_method")]
     method: HttpMethod,
     body: Option<String>,
     headers: Option<HashMap<String, String>>,
@@ -27,6 +28,10 @@ pub struct HTTPResponse {
     status_text: String,
     headers: HashMap<String, String>,
     body: String,
+}
+
+fn default_method() -> HttpMethod {
+    HttpMethod::GET
 }
 
 #[tauri::command]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -82,7 +82,8 @@
                 "resizable": true,
                 "title": "",
                 "width": 800,
-                "useHttpsScheme": true
+                "useHttpsScheme": true,
+                "backgroundColor": "#0b0b0b"
             }
         ],
         "security": {

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
+    "identifier": "co.runebook",
+    "app": {
+        "windows": [
+            {
+                "transparent": true
+            }
+        ]
+    }
+}

--- a/src/lib/engines/ollama.ts
+++ b/src/lib/engines/ollama.ts
@@ -1,6 +1,7 @@
 import { Ollama as OllamaClient } from 'ollama/browser';
 
 import type { Client, Options, Tool } from '$lib/engines/types';
+import { fetch } from '$lib/http';
 import type { IModel } from '$lib/models';
 import Message, { type IMessage } from "$lib/models/message";
 import OllamaMessage from '$lib/models/message/ollama';
@@ -10,7 +11,7 @@ export default class Ollama implements Client {
     client: OllamaClient;
 
     constructor(host: string) {
-        this.client = new OllamaClient({ host });
+        this.client = new OllamaClient({ host, fetch });
     }
 
     async chat(model: IModel, history: IMessage[], tools: Tool[] = [], options: Options = {}): Promise<IMessage> {

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import type { RequestInit } from "openai/_shims/web-types.mjs";
 
 import { info } from "$lib/logger";
 
@@ -9,6 +10,12 @@ export interface HttpOptions extends RequestInit {
     raw?: boolean;
     raise?: boolean;
     timeout?: number;
+}
+
+export async function fetch(url: string | URL | Request, options?: RequestInit) {
+    const response: globalThis.Response = await invoke('fetch', { url, options });
+    const { body, ...init } = response;
+    return new globalThis.Response(body, init);
 }
 
 export abstract class HttpClient {
@@ -72,9 +79,7 @@ export abstract class HttpClient {
         const opt = { ...this.options, ...options };
 
         try {
-            const resp: globalThis.Response = await invoke('fetch', { url: `${url}${uri}`, options: opt });
-            const { body, ...init } = resp;
-            response = new globalThis.Response(body, init);
+            response = await fetch(`${url}${uri}`, opt);
         } catch (err) {
             if (typeof err == 'string') {
                 info(`${opt.method} ${url}${uri}: ${err}`);


### PR DESCRIPTION
## CORS Issues with Ollama

#29 refactored the code that communicates with LLMs. With that, we moved to using first-party libraries like `ollama` and `openai`.  By default, they use the builtin browser `fetch` On Windows, Tauri uses a host of `http://localhost.tauri` (or something similar). This host is not on Ollama's list of accepted hosts, so we get a CORS error.

The `ollama` library lets you pass a custom `fetch` function, so we use our custom one that's proxied by the Rust backend. Thanks `ollama` devs 😬 

## Window GUI differences across platforms

### White Screen of Annoyance™

We needed to remove `transparent: true` from `tauri.conf.json`, because on Windows, it removes all app rendering for whatever reason. That causes the app to flash a blank white screen while Tauri initializes everything and renders the UI.

To fix this, we now set the `backgroundColor` of the window itself (this gets set directly on the window via Tauri/Wry's). This only fixes Windows – it seems like MacOS ignores this for some reason. To fix MacOS, we add a mac-specific config in `tauri.macos.conf.json` that sets `transparent: true`.

These changes remove the white screen flash on both platforms. Who knows what Linux will do someday... 🙃 