### PR TITLE
Adds Gemini support

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-    "useTabs": true,
+    "useTabs": false,
     "singleQuote": true,
     "tabWidth": 4,
     "semi": true,

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         ]
     },
     "dependencies": {
+        "@google/genai": "^1.0.0",
         "@tauri-apps/api": "^2.3.0",
         "@tauri-apps/plugin-deep-link": "~2",
         "@tauri-apps/plugin-fs": "^2.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@google/genai':
+        specifier: ^1.0.0
+        version: 1.0.0(@modelcontextprotocol/sdk@1.11.5)
       '@tauri-apps/api':
         specifier: ^2.3.0
         version: 2.3.0
@@ -40,7 +43,7 @@ importers:
         version: 0.5.15
       openai:
         specifier: ^4.98.0
-        version: 4.98.0
+        version: 4.98.0(ws@8.18.2)(zod@3.25.17)
       tailwind-merge:
         specifier: ^3.0.2
         version: 3.0.2
@@ -339,6 +342,12 @@ packages:
     resolution: {integrity: sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@google/genai@1.0.0':
+    resolution: {integrity: sha512-IQiL8UlPblGDrMhTuiHZbfMDVx0KY3eYkmB5Ro9wwyXovYCFIhL5ZC7LP42FjFUj0eWUa4Auo8Ixqf2dqx9JjA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.11.0
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -376,6 +385,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@modelcontextprotocol/sdk@1.11.5':
+    resolution: {integrity: sha512-gS7Q7IHpKxjVaNLMUZyTtatZ63ca3h418zPPntAhu/MvG5yfz/8HMcDAOpvpQfx3V3dsw9QQxk8RuFNrQhLlgA==}
+    engines: {node: '>=18'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -841,6 +854,10 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -856,12 +873,19 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.3:
+    resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
+    engines: {node: '>= 14'}
+
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -916,6 +940,16 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bignumber.js@9.3.0:
+    resolution: {integrity: sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==}
+
+  body-parser@2.2.0:
+    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
+    engines: {node: '>=18'}
+
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
@@ -925,6 +959,13 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -971,9 +1012,29 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-disposition@1.0.0:
+    resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
+    engines: {node: '>= 0.6'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.5:
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1032,6 +1093,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   detect-libc@1.0.3:
     resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
     engines: {node: '>=0.10'}
@@ -1047,6 +1112,16 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   enhanced-resolve@5.18.1:
     resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
@@ -1084,6 +1159,9 @@ packages:
     resolution: {integrity: sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1198,9 +1276,34 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
+
+  eventsource-parser@3.0.2:
+    resolution: {integrity: sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
+  express-rate-limit@7.5.0:
+    resolution: {integrity: sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: ^4.11 || 5 || ^5.0.0-beta.1
+
+  express@5.1.0:
+    resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
+    engines: {node: '>= 18'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1214,6 +1317,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-uri@3.0.6:
+    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -1233,6 +1339,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  finalhandler@2.1.0:
+    resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
+    engines: {node: '>= 0.8'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -1260,6 +1370,14 @@ packages:
     resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
     engines: {node: '>= 12.20'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1274,6 +1392,14 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  gaxios@6.7.1:
+    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
+    engines: {node: '>=14'}
+
+  gcp-metadata@6.1.1:
+    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
+    engines: {node: '>=14'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -1307,6 +1433,14 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  google-auth-library@9.15.1:
+    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
+    engines: {node: '>=14'}
+
+  google-logging-utils@0.0.2:
+    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -1316,6 +1450,10 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  gtoken@7.1.0:
+    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
+    engines: {node: '>=14.0.0'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -1344,8 +1482,20 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1362,9 +1512,16 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -1426,6 +1583,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
@@ -1440,6 +1600,10 @@ packages:
   is-shared-array-buffer@1.0.4:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
@@ -1479,11 +1643,17 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -1494,6 +1664,12 @@ packages:
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.0:
+    resolution: {integrity: sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -1605,6 +1781,14 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1617,8 +1801,16 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.1:
+    resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
     engines: {node: '>= 0.6'}
 
   minimatch@3.1.2:
@@ -1653,6 +1845,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -1666,6 +1862,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -1693,6 +1893,13 @@ packages:
 
   ollama@0.5.15:
     resolution: {integrity: sha512-TSaZSJyP7MQJFjSmmNsoJiriwa3U+/UJRw6+M8aucs5dTsaWNZsBIGpDb5rXnW6nXxJBB/z79gZY8IaiIQgelQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   openai@4.98.0:
     resolution: {integrity: sha512-TmDKur1WjxxMPQAtLG5sgBSCJmX7ynTsGmewKzoDwl1fRxtbLOsiR0FA/AOAAtYUmP6azal+MYQuOENfdU+7yg==}
@@ -1726,6 +1933,10 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1737,6 +1948,10 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-to-regexp@8.2.0:
+    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
+    engines: {node: '>=16'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1747,6 +1962,10 @@ packages:
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.0:
+    resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
+    engines: {node: '>=16.20.0'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -1858,12 +2077,28 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.14.0:
+    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+    engines: {node: '>=0.6'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.0:
+    resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
+    engines: {node: '>= 0.8'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -1876,6 +2111,10 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1895,6 +2134,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -1906,6 +2149,9 @@ packages:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -1913,6 +2159,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -1922,6 +2171,14 @@ packages:
     resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  send@1.2.0:
+    resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.0:
+    resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
+    engines: {node: '>= 18'}
 
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
@@ -1937,6 +2194,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1969,6 +2229,10 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
 
   string.prototype.trim@1.2.10:
     resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
@@ -2036,6 +2300,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -2055,6 +2323,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -2091,6 +2363,10 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -2099,6 +2375,14 @@ packages:
 
   uuid4@2.0.3:
     resolution: {integrity: sha512-CTpAkEVXMNJl2ojgtpLXHgz23dh8z81u6/HEPiQFOvBc/c2pde6TVHmH4uwY0d/GLF3tb7+VDAj4+2eJaQSdZQ==}
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@6.2.0:
     resolution: {integrity: sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ==}
@@ -2186,6 +2470,21 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.18.2:
+    resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
@@ -2201,6 +2500,14 @@ packages:
 
   zimmerframe@1.1.2:
     resolution: {integrity: sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==}
+
+  zod-to-json-schema@3.24.5:
+    resolution: {integrity: sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==}
+    peerDependencies:
+      zod: ^3.24.1
+
+  zod@3.25.17:
+    resolution: {integrity: sha512-8hQzQ/kMOIFbwOgPrm9Sf9rtFHpFUMy4HvN0yEB0spw14aYi0uT5xG5CE2DB9cd51GWNsz+DNO7se1kztHMKnw==}
 
 snapshots:
 
@@ -2332,6 +2639,19 @@ snapshots:
       '@eslint/core': 0.12.0
       levn: 0.4.1
 
+  '@google/genai@1.0.0(@modelcontextprotocol/sdk@1.11.5)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.11.5
+      google-auth-library: 9.15.1
+      ws: 8.18.2
+      zod: 3.25.17
+      zod-to-json-schema: 3.24.5(zod@3.25.17)
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -2361,6 +2681,22 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@modelcontextprotocol/sdk@1.11.5':
+    dependencies:
+      ajv: 8.17.1
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      express: 5.1.0
+      express-rate-limit: 7.5.0(express@5.1.0)
+      pkce-challenge: 5.0.0
+      raw-body: 3.0.0
+      zod: 3.25.17
+      zod-to-json-schema: 3.24.5(zod@3.25.17)
+    transitivePeerDependencies:
+      - supports-color
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -2783,6 +3119,11 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.1
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.14.0):
     dependencies:
       acorn: 8.14.0
@@ -2792,6 +3133,8 @@ snapshots:
       acorn: 8.14.0
 
   acorn@8.14.0: {}
+
+  agent-base@7.1.3: {}
 
   agentkeepalive@4.6.0:
     dependencies:
@@ -2803,6 +3146,13 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.0.6
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-styles@4.3.0:
     dependencies:
@@ -2872,6 +3222,24 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@1.5.1: {}
+
+  bignumber.js@9.3.0: {}
+
+  body-parser@2.2.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.0
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
+      on-finished: 2.4.1
+      qs: 6.14.0
+      raw-body: 3.0.0
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
@@ -2884,6 +3252,10 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  buffer-equal-constant-time@1.0.1: {}
+
+  bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -2929,7 +3301,22 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-disposition@1.0.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.2.2: {}
+
   cookie@0.6.0: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.5:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2983,6 +3370,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   detect-libc@1.0.3: {}
 
   devalue@5.1.1: {}
@@ -2996,6 +3385,14 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
 
   enhanced-resolve@5.18.1:
     dependencies:
@@ -3108,6 +3505,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.0
       '@esbuild/win32-ia32': 0.25.0
       '@esbuild/win32-x64': 0.25.0
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -3263,7 +3662,53 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   event-target-shim@5.0.1: {}
+
+  eventsource-parser@3.0.2: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.2
+
+  express-rate-limit@7.5.0(express@5.1.0):
+    dependencies:
+      express: 5.1.0
+
+  express@5.1.0:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.0
+      content-disposition: 1.0.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.0
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.1
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.0
+      serve-static: 2.2.0
+      statuses: 2.0.1
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -3278,6 +3723,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-uri@3.0.6: {}
 
   fastq@1.19.1:
     dependencies:
@@ -3294,6 +3741,17 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@2.1.0:
+    dependencies:
+      debug: 4.4.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   find-up@5.0.0:
     dependencies:
@@ -3325,6 +3783,10 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 4.0.0-beta.3
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
@@ -3340,6 +3802,26 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  gaxios@6.7.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      is-stream: 2.0.1
+      node-fetch: 2.7.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  gcp-metadata@6.1.1:
+    dependencies:
+      gaxios: 6.7.1
+      google-logging-utils: 0.0.2
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -3382,11 +3864,33 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  google-auth-library@9.15.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 6.7.1
+      gcp-metadata: 6.1.1
+      gtoken: 7.1.0
+      jws: 4.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  google-logging-utils@0.0.2: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  gtoken@7.1.0:
+    dependencies:
+      gaxios: 6.7.1
+      jws: 4.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   has-bigints@1.1.0: {}
 
@@ -3410,9 +3914,28 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  http-errors@2.0.0:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.0
+    transitivePeerDependencies:
+      - supports-color
+
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -3425,11 +3948,15 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inherits@2.0.4: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  ipaddr.js@1.9.1: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -3497,6 +4024,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-promise@4.0.0: {}
+
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.6
@@ -3513,6 +4042,8 @@ snapshots:
   is-shared-array-buffer@1.0.4:
     dependencies:
       call-bound: 1.0.4
+
+  is-stream@2.0.1: {}
 
   is-string@1.1.1:
     dependencies:
@@ -3550,9 +4081,15 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.0
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-schema@0.4.0: {}
 
@@ -3561,6 +4098,17 @@ snapshots:
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.0:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -3642,6 +4190,10 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -3651,9 +4203,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.1:
+    dependencies:
+      mime-db: 1.54.0
 
   minimatch@3.1.2:
     dependencies:
@@ -3677,11 +4235,15 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0: {}
+
   node-domexception@1.0.0: {}
 
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
@@ -3720,7 +4282,15 @@ snapshots:
     dependencies:
       whatwg-fetch: 3.6.20
 
-  openai@4.98.0:
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  openai@4.98.0(ws@8.18.2)(zod@3.25.17):
     dependencies:
       '@types/node': 18.19.100
       '@types/node-fetch': 2.6.12
@@ -3729,6 +4299,9 @@ snapshots:
       form-data-encoder: 1.7.2
       formdata-node: 4.4.1
       node-fetch: 2.7.0
+    optionalDependencies:
+      ws: 8.18.2
+      zod: 3.25.17
     transitivePeerDependencies:
       - encoding
 
@@ -3759,11 +4332,15 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-to-regexp@8.2.0: {}
 
   picocolors@1.1.1: {}
 
@@ -3771,6 +4348,8 @@ snapshots:
 
   picomatch@4.0.2:
     optional: true
+
+  pkce-challenge@5.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -3820,9 +4399,27 @@ snapshots:
 
   prettier@3.5.3: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   punycode@2.3.1: {}
 
+  qs@6.14.0:
+    dependencies:
+      side-channel: 1.1.0
+
   queue-microtask@1.2.3: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.0:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
+      unpipe: 1.0.0
 
   readdirp@4.1.2: {}
 
@@ -3845,6 +4442,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 
@@ -3881,6 +4480,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.34.9
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.0
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.2.0
+    transitivePeerDependencies:
+      - supports-color
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -3897,6 +4506,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.2.1: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -3908,9 +4519,36 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safer-buffer@2.1.2: {}
+
   semver@6.3.1: {}
 
   semver@7.7.1: {}
+
+  send@1.2.0:
+    dependencies:
+      debug: 4.4.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      mime-types: 3.0.1
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.0:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.0
+    transitivePeerDependencies:
+      - supports-color
 
   set-cookie-parser@2.7.1: {}
 
@@ -3935,6 +4573,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -3977,6 +4617,8 @@ snapshots:
       totalist: 3.0.1
 
   source-map-js@1.2.1: {}
+
+  statuses@2.0.1: {}
 
   string.prototype.trim@1.2.10:
     dependencies:
@@ -4063,6 +4705,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   totalist@3.0.1: {}
 
   tr46@0.0.3: {}
@@ -4081,6 +4725,12 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.1
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -4136,6 +4786,8 @@ snapshots:
 
   undici-types@5.26.5: {}
 
+  unpipe@1.0.0: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -4143,6 +4795,10 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid4@2.0.3: {}
+
+  uuid@9.0.1: {}
+
+  vary@1.1.2: {}
 
   vite@6.2.0(@types/node@18.19.100)(jiti@2.4.2)(lightningcss@1.29.1)(yaml@2.7.0):
     dependencies:
@@ -4218,6 +4874,10 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrappy@1.0.2: {}
+
+  ws@8.18.2: {}
+
   yaml@1.10.2: {}
 
   yaml@2.7.0:
@@ -4226,3 +4886,9 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zimmerframe@1.1.2: {}
+
+  zod-to-json-schema@3.24.5(zod@3.25.17):
+    dependencies:
+      zod: 3.25.17
+
+  zod@3.25.17: {}

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -169,5 +169,13 @@ CREATE TABLE IF NOT EXISTS config (
             "#,
             kind: MigrationKind::Up,
         },
+        Migration {
+            version: 12,
+            description: "add_gemini_api_key_setting",
+            sql: r#"
+INSERT INTO settings ("display", "key", "type") VALUES ("Gemini API Key", "gemini-api-key", "password");
+            "#,
+            kind: MigrationKind::Up,
+        },
     ]
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -18,13 +18,13 @@ declare global {
         compact<T>(o: Obj): T;
         without<T>(o: Obj, keys: string[]): T;
         remove<T>(o: Obj, key: string): T | undefined;
-        map<T>(o: Obj, fn: (key: string, value: any) => any): T;
+        map<T extends Obj>(o: T, fn: (key: string, value: any) => any): T;
     }
 
     interface Array<T> {
         sortBy<T extends Obj>(key: string): Array<T>;
         findBy<T extends Obj>(key: string, value: any): T | undefined;
-        compact(): Array<T>;
+        compact(): Array<Exclude<T, undefined>>;
     }
 
     interface CheckboxEvent extends Event {

--- a/src/components/Chat.svelte
+++ b/src/components/Chat.svelte
@@ -97,7 +97,7 @@
 <Flex class="h-content w-full flex-col p-8 pr-2 pb-0">
 	<Scrollable bind:ref={content} class="mb-8">
 		<!-- Chat Log -->
-		<div class:opacity-25={!model} class="bg-medium relative h-full w-full px-2">
+		<div class:opacity-25={!model} class="bg-medium relative w-full px-2">
 			{#each messages as message (message.id)}
 				<Flex id="messages" class="w-full flex-col items-start">
 					<!-- Svelte hack: ensure chat is always scrolled to the bottom when a new message is added -->

--- a/src/components/Messages/Assistant.svelte
+++ b/src/components/Messages/Assistant.svelte
@@ -16,7 +16,7 @@
 {/if}
 
 <Flex class="assistant text-medium mb-8 w-full justify-between p-2 text-xs">
-	<p class="message markdown-body text-sm whitespace-normal">
+	<p class="message markdown-body w-full text-sm whitespace-normal">
 		{@html markdown.render(message.content)}
 	</p>
 </Flex>

--- a/src/components/Scrollable.svelte
+++ b/src/components/Scrollable.svelte
@@ -12,7 +12,7 @@
 </script>
 
 <Flex bind:ref class={twMerge('h-full w-full items-start overflow-y-scroll', cls?.toString())}>
-	<div class="h-full w-full">
+	<div class="w-full">
 		{@render children?.()}
 	</div>
 

--- a/src/lib/engines/gemini/client.ts
+++ b/src/lib/engines/gemini/client.ts
@@ -1,0 +1,102 @@
+import { type GenerateContentConfig, GoogleGenAI, type GoogleGenAIOptions } from '@google/genai';
+
+import GeminiMessage from '$lib/engines/gemini/message';
+import GeminiTools from '$lib/engines/gemini/tool';
+import type { Client, Options, Tool, ToolCall } from '$lib/engines/types';
+import type { IMessage, IModel } from '$lib/models';
+
+export default class Gemini implements Client {
+    private client: GoogleGenAI;
+
+    id = 'gemini';
+
+    supportedModels = [
+        'models/gemini-2.5-pro-exp-03-25',
+        'models/gemini-2.0-flash',
+        'models/gemini-2.0-flash-lite',
+        'models/gemini-2.5-flash-preview-05-20',
+        'models/gemini-2.5-pro-preview-05-06',
+        'models/gemini-1.5-pro',
+    ];
+
+    constructor(options: GoogleGenAIOptions) {
+        this.client = new GoogleGenAI(options);
+    }
+
+    async chat(model: IModel, history: IMessage[], tools?: Tool[], options?: Options): Promise<IMessage> {
+        const messages = history.map(m => GeminiMessage.from(m)).compact();
+
+        let config: GenerateContentConfig = {
+            temperature: options?.temperature,
+        };
+
+        if (tools && tools.length) {
+            config = {
+                tools: GeminiTools.from(tools),
+            }
+        }
+
+        const { text, functionCalls } = await this.client.models.generateContent({
+            model: model.name,
+            contents: messages,
+            config,
+        });
+
+        let toolCalls: ToolCall[] = [];
+
+        if (functionCalls) {
+            toolCalls = functionCalls.map(tc => ({
+                function: {
+                    name: tc.name as string,
+                    arguments: tc.args || {},
+                }
+            }));
+        }
+
+        return {
+            model: model.name,
+            name: '',
+            role: 'assistant',
+            content: text || '',
+            toolCalls,
+        };
+    }
+
+    async models(): Promise<IModel[]> {
+        return (
+            await this.client.models.list()
+        )
+            .page
+            .filter(model => (
+                this.supportedModels.includes(model.name as string))
+            )
+            .map(model => {
+                const metadata = model;
+                const name = metadata.name?.replace('models/', '') as string;
+
+                return {
+                    id: `gemini:${name}`,
+                    name,
+                    metadata,
+                    supportsTools: true,
+                }
+            });
+    }
+
+    async info(model: string): Promise<IModel> {
+        const { name, displayName, ...metadata } = (
+            await this.client.models.get({ model })
+        );
+
+        return {
+            id: `gemini:${name}`,
+            name: displayName as string,
+            metadata,
+            supportsTools: true,
+        }
+    }
+
+    async connected(): Promise<boolean> {
+        return true;
+    }
+}

--- a/src/lib/engines/gemini/message.ts
+++ b/src/lib/engines/gemini/message.ts
@@ -1,0 +1,98 @@
+import type { Content } from "@google/genai";
+
+import { type IMessage, Session } from "$lib/models";
+
+export default {
+    from,
+}
+
+export function from(message: IMessage): Content | undefined {
+    if (message.role == 'user') {
+        return fromUser(message);
+    } else if (message.role == 'assistant' && !message.content) {
+        return fromToolCall(message);
+    } else if (message.role == 'assistant') {
+        return fromAssistant(message);
+    } else if (message.role == 'tool') {
+        return fromToolResponse(message);
+    } else if (message.role == 'system') {
+        return; // Gemini doesn't support System prompts
+    } else {
+        return fromAny(message);
+    }
+}
+
+function fromUser(message: IMessage): Content {
+    return {
+        role: 'user',
+        parts: [
+            {
+                text: message.content,
+            }
+        ]
+    }
+}
+
+function fromAssistant(message: IMessage): Content {
+    return {
+        role: 'model',
+        parts: [
+            {
+                text: message.content,
+            }
+        ]
+    }
+}
+
+function fromToolCall(message: IMessage): Content | undefined {
+    if (message.toolCalls.length == 0) {
+        return;
+    }
+
+    return {
+        role: 'model',
+        parts: [
+            {
+                functionCall: {
+                    id: message.toolCalls[0].id,
+                    name: message.toolCalls[0].function.name,
+                    args: message.toolCalls[0].function.arguments,
+                }
+            }
+        ]
+    }
+}
+
+function fromToolResponse(message: IMessage): Content {
+    // Find the `toolCall` message for this response
+    const session = Session.find(message.sessionId as number);
+    const messages = Session.messages(session);
+    const call = messages
+        .flatMap(m => m.toolCalls)
+        .find(tc => tc.id == message.toolCallId);
+
+    return {
+        role: 'user',
+        parts: [
+            {
+                functionResponse: {
+                    name: call?.function.name,
+                    response: {
+                        result: message.content,
+                    }
+                },
+            }
+        ]
+    }
+}
+
+function fromAny(message: IMessage): Content {
+    return {
+        role: message.role,
+        parts: [
+            {
+                text: message.content,
+            }
+        ]
+    }
+}

--- a/src/lib/engines/gemini/tool.ts
+++ b/src/lib/engines/gemini/tool.ts
@@ -1,0 +1,75 @@
+import { type FunctionDeclaration, type ToolListUnion, Type } from "@google/genai";
+
+import type { Tool } from '$lib/engines/types';
+
+/**
+ * Transform canonical Tool(s) into a Gemini-specific shape.
+ *
+ * The Gemini library uses specific enums and values for certain fields, so we
+ * need to convert our canonical (from `lib/engines/types`) objects into what
+ * the Gemini expects.
+ *
+ * @example
+ * ```ts
+ * import type { Tool } from '$lib/engines/types';
+ * import GeminiTools from '$lib/engines/gemini/tool';
+ * 
+ * const tool = {...} as Tool;
+ *
+ * GeminiTools.from([tool]);
+ * // => [<FunctionDeclaration>]
+ *
+ * GeminiTools.from(tool);
+ * // => [<FunctionDeclaration>]
+ * ```
+ */
+function from(tools: Tool | Tool[]): ToolListUnion {
+    return [
+        {
+            functionDeclarations: Array.isArray(tools)
+                ? fromMany(tools)
+                : [fromOne(tools)]
+        }
+    ]
+}
+
+function fromMany(tools: Tool[]): FunctionDeclaration[] {
+    return tools.map(tool => fromOne(tool));
+}
+
+function fromOne(tool: Tool): FunctionDeclaration {
+    const properties = Object.map(
+        tool.function.parameters.properties,
+        (name, prop) => ([
+            name,
+            {
+                ...prop,
+                type: toGeminiType(prop.type),
+            }
+        ])
+    );
+
+    return {
+        ...tool.function,
+        parameters: {
+            ...tool.function.parameters,
+            type: Type.OBJECT,
+            properties,
+        },
+    } as FunctionDeclaration;
+}
+
+function toGeminiType(type: string): Type {
+    return {
+        'string': Type.STRING,
+        'number': Type.NUMBER,
+        'boolean': Type.BOOLEAN,
+        'integer': Type.INTEGER,
+        'array': Type.ARRAY,
+        'object': Type.OBJECT,
+    }[type] || Type.STRING;
+}
+
+export default {
+    from,
+}

--- a/src/lib/engines/ollama/client.ts
+++ b/src/lib/engines/ollama/client.ts
@@ -1,21 +1,25 @@
 import { Ollama as OllamaClient } from 'ollama/browser';
 
-import type { Client, Options, Tool } from '$lib/engines/types';
+import OllamaMessage from '$lib/engines/ollama/message';
+import type { Client, Options, Role, Tool } from '$lib/engines/types';
 import { fetch } from '$lib/http';
 import type { IModel } from '$lib/models';
 import Message, { type IMessage } from "$lib/models/message";
-import OllamaMessage from '$lib/models/message/ollama';
 import Setting from "$lib/models/setting";
 
 export default class Ollama implements Client {
     client: OllamaClient;
+
+    message = OllamaMessage;
+    modelRole = 'assistant' as Role;
+    toolRole = 'tool' as Role;
 
     constructor(host: string) {
         this.client = new OllamaClient({ host, fetch });
     }
 
     async chat(model: IModel, history: IMessage[], tools: Tool[] = [], options: Options = {}): Promise<IMessage> {
-        const messages = history.map(m => OllamaMessage.from(m));
+        const messages = history.map(m => this.message.from(m));
         const response = await this.client.chat({
             model: model.name,
             messages,
@@ -40,7 +44,7 @@ export default class Ollama implements Client {
 
         return Message.default({
             model: model.name,
-            role: 'assistant',
+            role: this.modelRole,
             content,
             thought,
             toolCalls: response.message.tool_calls || [],

--- a/src/lib/engines/ollama/message.ts
+++ b/src/lib/engines/ollama/message.ts
@@ -1,0 +1,20 @@
+import type { Message } from "ollama";
+
+import type { IMessage } from "$lib/models/message";
+
+export default {
+    from,
+}
+
+export function from(message: IMessage): Message {
+    return {
+        role: message.role,
+        content: message.content,
+        tool_calls: message.toolCalls?.map(c => ({
+            function: {
+                name: c.function.name,
+                arguments: c.function.arguments,
+            }
+        }))
+    }
+}

--- a/src/lib/engines/openai/message.ts
+++ b/src/lib/engines/openai/message.ts
@@ -1,0 +1,65 @@
+import { OpenAI } from "openai";
+
+import type { IMessage } from "$lib/models/message";
+
+export default {
+    from,
+}
+
+export function from(message: IMessage): OpenAI.ChatCompletionMessageParam {
+    if (message.role == 'assistant') {
+        return fromAssistant(message);
+    } else if (message.role == 'system') {
+        return fromSystem(message);
+    } else if (['tool', 'function'].includes(message.role)) {
+        return fromTool(message);
+    } else {
+        return fromUser(message);
+    }
+}
+
+export function fromUser(message: IMessage): OpenAI.ChatCompletionUserMessageParam {
+    return {
+        role: 'user',
+        content: message.content,
+    }
+}
+
+export function fromAssistant(message: IMessage): OpenAI.ChatCompletionAssistantMessageParam {
+    return {
+        role: 'assistant',
+        content: message.content,
+        tool_calls: toolCalls(message),
+    }
+}
+
+export function fromTool(message: IMessage): OpenAI.ChatCompletionToolMessageParam {
+    return {
+        tool_call_id: message.toolCallId as string,
+        role: 'tool',
+        content: message.content,
+    }
+}
+
+export function fromSystem(message: IMessage): OpenAI.ChatCompletionSystemMessageParam {
+    return {
+        role: 'system',
+        content: message.content,
+    }
+}
+
+function toolCalls(message: IMessage): OpenAI.ChatCompletionMessageToolCall[] | undefined {
+    if (message.toolCalls.length == 0) {
+        return;
+    }
+
+    return message.toolCalls.map(call => ({
+        id: call.id as string,
+        type: 'function',
+        function: {
+            name: call.function.name,
+            arguments: JSON.stringify(call.function.arguments),
+        }
+    }));
+}
+

--- a/src/lib/engines/types.ts
+++ b/src/lib/engines/types.ts
@@ -1,7 +1,7 @@
 import type { IMessage, IModel } from "$lib/models";
 
 export interface Client {
-    chat(model: IModel, messages: Message[], tools?: Tool[], options?: Options): Promise<IMessage>;
+    chat(model: IModel, history: IMessage[], tools?: Tool[], options?: Options): Promise<IMessage>;
     models(): Promise<IModel[]>;
     info(model: string): Promise<IModel>;
     connected(): Promise<boolean>;
@@ -17,7 +17,10 @@ export type Role =
     | 'user'
     | 'assistant'
     | 'tool'
-    | 'function';
+    | 'function'
+    | 'developer' // openai
+    | 'model' // gemini
+    ;
 
 export interface Message {
     role: Role;
@@ -50,7 +53,7 @@ export interface Tool {
     }
 }
 
-interface Property {
+export interface Property {
     type: string;
     description: string;
 }

--- a/src/lib/ext.ts
+++ b/src/lib/ext.ts
@@ -61,7 +61,7 @@ Object.remove = function <T>(o: Obj, key: string): T | undefined {
 /**
  * Map over the entries of an object
  */
-Object.map = function <T>(o: Obj, fn: (key: string, value: any) => any): T {
+Object.map = function <T extends Obj>(o: T, fn: (key: string, value: any) => any): T {
     return Object.fromEntries(Object.entries(o).map(([k, v]) => fn(k, v))) as T;
 }
 
@@ -105,6 +105,6 @@ Array.prototype.findBy = function <T extends Obj>(this: T[], key: string, value:
  * assertEq(items.compact(), [1, 2, 3]);
  * ```
  */
-Array.prototype.compact = function <T>(this: T[]): T[] {
-    return this.filter(i => i !== undefined);
+Array.prototype.compact = function <T>(this: T[]): Exclude<T, undefined>[] {
+    return this.filter(i => i !== undefined) as Exclude<T, undefined>[];
 }

--- a/src/lib/models/engine.ts
+++ b/src/lib/models/engine.ts
@@ -1,5 +1,6 @@
-import Ollama from '$lib/engines/ollama';
-import OpenAI from '$lib/engines/openai'
+import Gemini from '$lib/engines/gemini/client';
+import Ollama from '$lib/engines/ollama/client';
+import OpenAI from '$lib/engines/openai/client';
 import type { Client } from '$lib/engines/types';
 import { Setting } from '$lib/models';
 import { BareModel } from '$lib/models/base.svelte';
@@ -32,7 +33,7 @@ export default class Engine extends BareModel<IEngine>() {
         }
 
         if (Setting.OpenAIKey) {
-            const client = new OpenAI(Setting.OpenAIKey);
+            const client = new OpenAI({ apiKey: Setting.OpenAIKey });
 
             this.add({
                 id: 'openai',
@@ -42,6 +43,16 @@ export default class Engine extends BareModel<IEngine>() {
             });
         }
 
+        if (Setting.GeminiApiKey) {
+            const client = new Gemini({ apiKey: Setting.GeminiApiKey });
+
+            this.add({
+                id: 'gemini',
+                name: 'Gemini',
+                client,
+                models: (await client.models()).sortBy('name'),
+            });
+        }
         Model.reset(
             this.all().flatMap(engine => engine.models)
         );

--- a/src/lib/models/message.ts
+++ b/src/lib/models/message.ts
@@ -3,7 +3,6 @@ import moment from "moment";
 import type { Role, ToolCall } from "$lib/engines/types";
 import Model, { type ToSqlRow } from '$lib/models/base.svelte';
 import Session, { type ISession } from "$lib/models/session";
-import { info } from "$lib/logger";
 
 export interface IMessage {
     id?: number;
@@ -45,7 +44,6 @@ export default class Message extends Model<IMessage, Row>('messages') {
     };
 
     static response(message: IMessage): IMessage | undefined {
-        info(message.toolCalls[0].id);
         return Message.findBy({ toolCallId: message.toolCalls[0].id });
     }
 

--- a/src/lib/models/setting.ts
+++ b/src/lib/models/setting.ts
@@ -1,9 +1,12 @@
-import Ollama from '$lib/engines/ollama';
+import Ollama from '$lib/engines/ollama/client';
 import Model, { type ToSqlRow } from '$lib/models/base.svelte';
 import Engine from '$lib/models/engine';
 
 // OpenAI API Key
 const OPENAI_API_KEY = 'openai-api-key';
+
+// Gemini API Key
+const GEMINI_API_KEY = 'gemini-api-key';
 
 // Ollama URL
 export const OLLAMA_URL_CONFIG_KEY = 'ollama-url';
@@ -31,6 +34,10 @@ export default class Setting extends Model<ISetting, Row>('settings') {
 
     static get OpenAIKey(): string | undefined {
         return this.findBy({ key: OPENAI_API_KEY })?.value as string | undefined;
+    }
+
+    static get GeminiApiKey(): string | undefined {
+        return this.findBy({ key: GEMINI_API_KEY })?.value as string | undefined;
     }
 
     static async validate(setting: ISetting): Promise<boolean> {

--- a/src/routes/models/+page.svelte
+++ b/src/routes/models/+page.svelte
@@ -1,81 +1,86 @@
 <script lang="ts">
-	import { twMerge } from 'tailwind-merge';
+    import { onMount } from 'svelte';
+    import { twMerge } from 'tailwind-merge';
 
-	import Box from '$components/Box.svelte';
-	import Flex from '$components/Flex.svelte';
-	import Layout from '$components/Layouts/Default.svelte';
-	import Svg from '$components/Svg.svelte';
-	import { Engine, type IEngine, type IModel } from '$lib/models';
-	import Config from '$lib/models/config';
-	import { onMount } from 'svelte';
+    import Box from '$components/Box.svelte';
+    import Flex from '$components/Flex.svelte';
+    import Layout from '$components/Layouts/Default.svelte';
+    import Svg from '$components/Svg.svelte';
+    import { Engine, type IEngine, type IModel } from '$lib/models';
+    import Config from '$lib/models/config';
 
-	const engines: IEngine[] = Engine.all();
+    const engines: IEngine[] = Engine.all();
 
-	function isDefault(model: IModel) {
-		return Config.defaultModel == model.id;
-	}
+    function isDefault(model: IModel) {
+        return Config.defaultModel == model.id;
+    }
 
-	function setDefault(model: IModel) {
-		Config.defaultModel = model.id;
-	}
+    function setDefault(model: IModel) {
+        Config.defaultModel = model.id;
+    }
 
-	onMount(async () => {
-		await Engine.sync();
-	});
+    onMount(async () => {
+        await Engine.sync();
+    });
 </script>
 
 {#snippet titlebar()}
-	<Flex class=" h-full w-[300px] items-center px-8 pr-4">
-		<h1 class="font-[500]">Models</h1>
-	</Flex>
+    <Flex class=" h-full w-[300px] items-center px-8 pr-4">
+        <h1 class="font-[500]">Models</h1>
+    </Flex>
 {/snippet}
 
 {#snippet label(text: string, css: string)}
-	<p
-		class={twMerge(
-			css,
-			'mx-1 rounded-xs px-1 py-0 text-[9px] leading-[16px] font-semibold text-[#000] uppercase'
-		)}
-	>
-		{text}
-	</p>
+    <p
+        class={twMerge(
+            css,
+            'mx-1 rounded-xs px-1 py-0 text-[9px] leading-[16px] font-semibold text-[#000] uppercase'
+        )}
+    >
+        {text}
+    </p>
 {/snippet}
 
 <Layout {titlebar}>
-	<Flex class="w-full flex-col items-start gap-2 p-8">
-		{#each engines as engine (engine.id)}
-			<div class="mb-16 w-full">
-				<h2 class="mb-4 ml-6 text-2xl">{engine.name}</h2>
-				<Flex class="grid w-full grid-cols-3 gap-6 gap-y-4">
-					{#each engine.models as model (model.id)}
-						<Box class="border-light group mb-2 flex-row items-center border pl-6">
-							<h3 class="text-light">{model.name}</h3>
+    <div class="h-full w-full overflow-y-auto">
+        <Flex class="w-full flex-col items-start gap-2 p-8">
+            {#each engines as engine (engine.id)}
+                <div class="mb-16 w-full">
+                    <h2 class="mb-4 ml-6 text-2xl">{engine.name}</h2>
+                    <Flex class="grid w-full grid-cols-3 gap-6 gap-y-4">
+                        {#each engine.models as model (model.id)}
+                            <Box class="border-light group mb-2 flex-row items-center border pl-6">
+                                <h3 class="text-light">{model.name}</h3>
 
-							<button
-								onclick={() => setDefault(model)}
-								class={`ml-2 h-4 w-4 group-hover:block hover:cursor-pointer
+                                <button
+                                    onclick={() => setDefault(model)}
+                                    class={`ml-2 h-4 w-4 group-hover:block hover:cursor-pointer
                                 ${isDefault(model) ? 'fill-yellow' : 'stroke-yellow hidden'}`}
-							>
-								<Svg name="Star" title="Default Model" />
-							</button>
+                                >
+                                    <Svg name="Star" title="Default Model" />
+                                </button>
 
-							<Flex class="grow justify-end">
-								{#if model.metadata?.details}
-									{@render label(model.metadata.details.format, 'bg-[#7aa2f7]')}
-									{@render label(
-										model.metadata.details.parameter_size,
-										'bg-[#ff9e64]'
-									)}
-									{@render label(
-										model.metadata.details.quantization_level,
-										'bg-[#41a6b5]'
-									)}
-								{/if}
-							</Flex>
-						</Box>
-					{/each}
-				</Flex>
-			</div>
-		{/each}
-	</Flex>
+                                <Flex class="grow justify-end">
+                                    {#if model.metadata?.details}
+                                        {@render label(
+                                            model.metadata.details.format,
+                                            'bg-[#7aa2f7]'
+                                        )}
+                                        {@render label(
+                                            model.metadata.details.parameter_size,
+                                            'bg-[#ff9e64]'
+                                        )}
+                                        {@render label(
+                                            model.metadata.details.quantization_level,
+                                            'bg-[#41a6b5]'
+                                        )}
+                                    {/if}
+                                </Flex>
+                            </Box>
+                        {/each}
+                    </Flex>
+                </div>
+            {/each}
+        </Flex>
+    </div>
 </Layout>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,50 +1,50 @@
 <script lang="ts">
-	import Box from '$components/Box.svelte';
-	import Flex from '$components/Flex.svelte';
-	import Layout from '$components/Layouts/Default.svelte';
-	import Svg from '$components/Svg.svelte';
-	import Titlebar from '$components/Titlebar.svelte';
-	import Setting, { type ISetting } from '$lib/models/setting';
+    import Box from '$components/Box.svelte';
+    import Flex from '$components/Flex.svelte';
+    import Layout from '$components/Layouts/Default.svelte';
+    import Svg from '$components/Svg.svelte';
+    import Titlebar from '$components/Titlebar.svelte';
+    import Setting, { type ISetting } from '$lib/models/setting';
 
-	const settings: ISetting[] = $derived(Setting.all());
+    const settings: ISetting[] = $derived(Setting.all());
 
-	let saving = $state(false);
+    let saving = $state(false);
 
-	async function save(setting: ISetting) {
-		saving = true;
-		await Setting.save(setting);
-		setTimeout(() => (saving = false), 1000);
-	}
+    async function save(setting: ISetting) {
+        saving = true;
+        await Setting.save(setting);
+        setTimeout(() => (saving = false), 1000);
+    }
 </script>
 
 {#snippet titlebar()}
-	<Titlebar class="h-[60px] w-full">
-		<Flex class="h-full px-8 pr-4">
-			<h1 class="font-[500]">Settings</h1>
-			<div class={`text-green mt-[2px] ml-4 h-4 w-4 ${saving ? 'opacity-100' : 'opacity-0'}`}>
-				<Svg name="Check" />
-			</div>
-		</Flex>
-	</Titlebar>
+    <Titlebar class="h-[60px] w-full">
+        <Flex class="h-full px-8 pr-4">
+            <h1 class="font-[500]">Settings</h1>
+            <div class={`text-green mt-[2px] ml-4 h-4 w-4 ${saving ? 'opacity-100' : 'opacity-0'}`}>
+                <Svg name="Check" />
+            </div>
+        </Flex>
+    </Titlebar>
 {/snippet}
 
 <Layout {titlebar}>
-	<Flex class="w-full flex-col gap-4 p-8">
-		{#each settings as setting (setting.id)}
-			<Box class="mt-4 w-full flex-col items-start">
-				<label for={setting.key} class="text-light/80 -mt-8 ml-3">
-					{setting.display}
-				</label>
+    <Flex class="w-full flex-col gap-4 p-8">
+        {#each settings as setting (setting.id)}
+            <Box class="mt-4 w-full flex-col items-start">
+                <label for={setting.key} class="text-light/80 -mt-8 ml-3">
+                    {setting.display}
+                </label>
 
-				<input
-					type={setting.type}
-					class="border-light bg-medium text-light mt-2 w-full
+                <input
+                    type={setting.type}
+                    class="border-light bg-medium text-light mt-2 w-full
                     rounded-md border p-2 px-4 outline-none"
-					name={setting.key}
-					bind:value={setting.value}
-					onchange={() => save(setting)}
-				/>
-			</Box>
-		{/each}
-	</Flex>
+                    name={setting.key}
+                    bind:value={setting.value}
+                    onchange={() => save(setting)}
+                />
+            </Box>
+        {/each}
+    </Flex>
 </Layout>


### PR DESCRIPTION
This change does two main things:

- Engine Refactor
- Gemini Support

## Engine Refactor

Story time. At first I thought we could use the OpenAI API compatibility of Gemini to reuse most of our OpenAI code. Turns out we can't. Google on implements a portion of it and it's experimental and incomplete.

So I decided to use the `@google/genai` library to directly work with the Gemini API in the way Google intends. This led to needing to format Messages and Tools in a specific way to appease the Gemini API.

This may be the case for any Engine we implement in the future, so I standardized the process a little bit.

### Directory Structure

```
lib/engines/
    |- gemini
    |   |- client.ts
    |   |- message.ts
    |   `- tool.ts
    |- openai
    |   |- client.ts
    |   `- message.ts
    `- ollama
        |- client.ts
        |- message.ts
        `- tool.ts
```

### `client.ts`

Clients are the class that communicates with the engine's backend. It must conform to a [specific interface](https://github.com/runebookai/tome/blob/main/src/lib/engines/types.ts#L3). It's the object `dispatch` uses to send off messages to the LLM.

### `message.ts`

Engines will often require us to send Message history in different formats. Each Engine will have a `message.ts` module to convert our canonical objects (found in [`lib/engines/types.ts`](https://github.com/runebookai/tome/blob/main/src/lib/engines/types.ts)).

These modules should export the same interface. Namely, a default object with a `from` function. The `from` function should be overloaded to convert one or more canonical `IMessage` objects into the appropriate shape for the engine.

```ts
export default {
    from,
}

function from(message: IMessage): GeminiContent[];
function from(messages: IMessage[]): GeminiContent[];
function from(messages: IMessage | IMessage[]): GeminiContent[] {
    return Array.isArray(messages)
        ? convertMany(messages)
        : [convertOne(messages)];
}
```

### `tool.ts`

Engines will also often have a specific format they expect `tools` – if they support tool calling. `tools.ts` is the same idea as `messages.ts`, but for the `tools` array we pass to each chat API request.

These files should export the same interface as `message.ts`, but for Tools (obviously).

```ts
export default {
    from,
}

function from(tool: Tool): FunctionDeclaration[];
function from(tools: Tool[]): FunctionDeclaration[];
function from(tools: Tool | Tool[]): FunctionDeclaration[] {
    return Array.isArray(tools)
        ? convertMany(tools)
        : [convertOne(tools)];
}
```

## Gemini Support

The above refactor was to facilitate adding Gemini. A new engine (`lib/engines/gemini`) was added to support Google's Gemini models.