### PR TITLE
Adds python, node, and bunx MCP command support

### DIFF
--- a/src-tauri/build/platform/windows/bin/bunx.cmd
+++ b/src-tauri/build/platform/windows/bin/bunx.cmd
@@ -1,0 +1,42 @@
+@ECHO OFF
+SETLOCAL EnableDelayedExpansion
+
+SET "SCRIPT_DIR=%~dp0"
+
+:: Check if we already have bun installed
+if exist "C:\Users\me\AppData\Roaming\npm\bunx.cmd" (
+    goto :bun_found
+)
+
+:: Check if Node.js is installed in Program Files
+if exist "C:\Program Files\nodejs\node.exe" (
+    echo Node.js found in Program Files
+    set "NPM_EXE=C:\Program Files\nodejs\npm.cmd"
+    goto :node_found
+)
+
+:: Check if Node.js is installed in Program Files (x86)
+if exist "C:\Program Files (x86)\nodejs\node.exe" (
+    echo Node.js found in Program Files (x86)
+    set "NPM_EXE=C:\Program Files (x86)\nodejs\npm.cmd"
+    goto :node_found
+)
+
+REM If Node.js not found, run installer
+call "%SCRIPT_DIR%install-node.cmd" "https://nodejs.org/dist/v23.10.0/node-v23.10.0-x64.msi"
+set "NPM_EXE=C:\Program Files\nodejs\npm.cmd"
+if errorlevel 1 (
+    echo Failed to install Node.js
+    exit /b 1
+)
+
+:node_found
+
+:: Install "bunx
+cmd.exe /c "%NPM_EXE%" install -g bun@1.2
+
+:bun_found
+
+:: Use bunx
+"C:\Users\me\AppData\Roaming\npm\bun.cmd" x %*
+exit /b %errorlevel%

--- a/src-tauri/build/platform/windows/bin/node.cmd
+++ b/src-tauri/build/platform/windows/bin/node.cmd
@@ -1,0 +1,31 @@
+@ECHO OFF
+SETLOCAL EnableDelayedExpansion
+
+SET "SCRIPT_DIR=%~dp0"
+
+REM Try to find Node.js in standard locations first
+if exist "C:\Program Files\nodejs\node.exe" (
+    "C:\Program Files\nodejs\node.exe" %*
+    exit /b %errorlevel%
+)
+
+if exist "C:\Program Files (x86)\nodejs\node.exe" (
+    "C:\Program Files (x86)\nodejs\node.exe" %*
+    exit /b %errorlevel%
+)
+
+REM If Node.js not found, run installer
+call "%SCRIPT_DIR%install-node.cmd" "https://nodejs.org/dist/v23.10.0/node-v23.10.0-x64.msi"
+if errorlevel 1 (
+    echo Failed to install Node.js
+    exit /b 1
+)
+
+REM Try using the newly installed Node.js
+if exist "C:\Program Files\nodejs\node.exe" (
+    "C:\Program Files\nodejs\node.exe" %*
+    exit /b %errorlevel%
+)
+
+echo Failed to find node after Node.js installation
+exit /b 1

--- a/src-tauri/bunx
+++ b/src-tauri/bunx
@@ -1,0 +1,68 @@
+#!/bin/bash
+# This product includes software developed at Square, Inc.
+# 
+# The Initial Developer of some parts of the framework, which are copied 
+# from, derived from, or inspired by Hermit, is Square, Inc. (https://squareup.com).
+# Copyright 2021 Square, Inc. All Rights Reserved.
+# 
+# The Initial Developer of Hermit is Square, Inc. (http://www.squareup.com).
+# Copyright 2021 Square, Inc. All Rights Reserved.
+
+set -euo pipefail
+LOGFILE="$HOME/Library/Logs/co.runebook/Tome.log"
+echo >> $LOGFILE
+
+log() {
+    local LINE="$1"
+    local DATE="$(date +'%Y-%m-%d')"
+    local TIME="$(date +'%H:%M:%S')"
+    echo "[$DATE][$TIME][hermit][DEBUG] $LINE" >> $LOGFILE
+}
+trap 'log "ERROR: Exiting w/ status: $?."' ERR
+
+log "Starting..."
+
+log "mkdir -p ~/.config/runebook/hermit/bin ?"
+mkdir -p ~/.config/runebook/hermit/bin
+
+log "cd ~/.config/runebook/hermit"
+cd ~/.config/runebook/hermit
+
+if [ ! -f ~/.config/runebook/hermit/bin/hermit ]; then
+    log "Downloading hermit..."
+    curl -fsSL "https://github.com/cashapp/hermit/releases/download/stable/hermit-$(uname -s \
+        | tr '[:upper:]' '[:lower:]')-$(uname -m \
+        | sed 's/x86_64/amd64/' \
+        | sed 's/aarch64/arm64/').gz" \
+        | gzip -dc > ~/.config/runebook/hermit/bin/hermit
+    log "Downloaded hermit..."
+
+    log "chmod +x ~/.config/runebook/hermit/bin/hermit"
+    chmod +x ~/.config/runebook/hermit/bin/hermit
+else
+    log "Found existing hermit..."
+fi
+
+log "mkdir -p ~/.config/runebook/hermit/cache"
+mkdir -p ~/.config/runebook/hermit/cache
+
+log "export HERMIT_STATE_DIR=~/.config/runebook/hermit/cache"
+export HERMIT_STATE_DIR=~/.config/runebook/hermit/cache
+
+log "export PATH=~/.config/runebook/hermit/bin:$PATH"
+export PATH=~/.config/runebook/hermit/bin:$PATH
+
+log "hermit init"
+hermit init >> "$LOGFILE"
+
+log "chmod +x hermit"
+chmod +x ~/.config/runebook/hermit/bin/hermit
+
+log "hermit install bun@1.2 >> "$LOGFILE""
+hermit install bun@1.2 >> "$LOGFILE"
+
+log "bun x $*"
+bun x "$@" || log "Error running bunx $*"
+
+log "End."
+

--- a/src-tauri/node
+++ b/src-tauri/node
@@ -1,0 +1,67 @@
+#!/bin/bash
+# This product includes software developed at Square, Inc.
+# 
+# The Initial Developer of some parts of the framework, which are copied 
+# from, derived from, or inspired by Hermit, is Square, Inc. (https://squareup.com).
+# Copyright 2021 Square, Inc. All Rights Reserved.
+# 
+# The Initial Developer of Hermit is Square, Inc. (http://www.squareup.com).
+# Copyright 2021 Square, Inc. All Rights Reserved.
+
+set -euo pipefail
+LOGFILE="$HOME/Library/Logs/co.runebook/Tome.log"
+echo >> $LOGFILE
+
+log() {
+    local LINE="$1"
+    local DATE="$(date +'%Y-%m-%d')"
+    local TIME="$(date +'%H:%M:%S')"
+    echo "[$DATE][$TIME][hermit][DEBUG] $LINE" >> $LOGFILE
+}
+trap 'log "ERROR: Exiting w/ status: $?."' ERR
+
+log "Starting..."
+
+log "mkdir -p ~/.config/runebook/hermit/bin ?"
+mkdir -p ~/.config/runebook/hermit/bin
+
+log "cd ~/.config/runebook/hermit"
+cd ~/.config/runebook/hermit
+
+if [ ! -f ~/.config/runebook/hermit/bin/hermit ]; then
+    log "Downloading hermit..."
+    curl -fsSL "https://github.com/cashapp/hermit/releases/download/stable/hermit-$(uname -s \
+        | tr '[:upper:]' '[:lower:]')-$(uname -m \
+        | sed 's/x86_64/amd64/' \
+        | sed 's/aarch64/arm64/').gz" \
+        | gzip -dc > ~/.config/runebook/hermit/bin/hermit
+    log "Downloaded hermit..."
+
+    log "chmod +x ~/.config/runebook/hermit/bin/hermit"
+    chmod +x ~/.config/runebook/hermit/bin/hermit
+else
+    log "Found existing hermit..."
+fi
+
+log "mkdir -p ~/.config/runebook/hermit/cache"
+mkdir -p ~/.config/runebook/hermit/cache
+
+log "export HERMIT_STATE_DIR=~/.config/runebook/hermit/cache"
+export HERMIT_STATE_DIR=~/.config/runebook/hermit/cache
+
+log "export PATH=~/.config/runebook/hermit/bin:$PATH"
+export PATH=~/.config/runebook/hermit/bin:$PATH
+
+log "hermit init"
+hermit init >> "$LOGFILE"
+
+log "chmod +x hermit"
+chmod +x ~/.config/runebook/hermit/bin/hermit
+
+log "hermit install node >> "$LOGFILE""
+hermit install node@lts >> "$LOGFILE"
+
+log "node $*"
+node "$@" || log "Error running node $*"
+
+log "End."

--- a/src-tauri/python
+++ b/src-tauri/python
@@ -1,0 +1,67 @@
+#!/bin/bash
+# This product includes software developed at Square, Inc.
+# 
+# The Initial Developer of some parts of the framework, which are copied 
+# from, derived from, or inspired by Hermit, is Square, Inc. (https://squareup.com).
+# Copyright 2021 Square, Inc. All Rights Reserved.
+# 
+# The Initial Developer of Hermit is Square, Inc. (http://www.squareup.com).
+# Copyright 2021 Square, Inc. All Rights Reserved.
+
+set -euo pipefail
+LOGFILE="$HOME/Library/Logs/co.runebook/Tome.log"
+echo >> $LOGFILE
+
+log() {
+    local LINE="$1"
+    local DATE="$(date +'%Y-%m-%d')"
+    local TIME="$(date +'%H:%M:%S')"
+    echo "[$DATE][$TIME][hermit][DEBUG] $LINE" >> $LOGFILE
+}
+trap 'log "ERROR: Exiting w/ status: $?."' ERR
+
+log "Starting..."
+
+log "mkdir -p ~/.config/runebook/hermit/bin ?"
+mkdir -p ~/.config/runebook/hermit/bin
+
+log "cd ~/.config/runebook/hermit"
+cd ~/.config/runebook/hermit
+
+if [ ! -f ~/.config/runebook/hermit/bin/hermit ]; then
+    log "Downloading hermit..."
+    curl -fsSL "https://github.com/cashapp/hermit/releases/download/stable/hermit-$(uname -s \
+        | tr '[:upper:]' '[:lower:]')-$(uname -m \
+        | sed 's/x86_64/amd64/' \
+        | sed 's/aarch64/arm64/').gz" \
+        | gzip -dc > ~/.config/runebook/hermit/bin/hermit
+    log "Downloaded hermit..."
+
+    log "chmod +x ~/.config/runebook/hermit/bin/hermit"
+    chmod +x ~/.config/runebook/hermit/bin/hermit
+else
+    log "Found existing hermit..."
+fi
+
+log "mkdir -p ~/.config/runebook/hermit/cache"
+mkdir -p ~/.config/runebook/hermit/cache
+
+log "export HERMIT_STATE_DIR=~/.config/runebook/hermit/cache"
+export HERMIT_STATE_DIR=~/.config/runebook/hermit/cache
+
+log "export PATH=~/.config/runebook/hermit/bin:$PATH"
+export PATH=~/.config/runebook/hermit/bin:$PATH
+
+log "hermit init"
+hermit init >> "$LOGFILE"
+
+log "chmod +x hermit"
+chmod +x ~/.config/runebook/hermit/bin/hermit
+
+log "hermit install python@3.12"
+hermit install python3@3.12 >> "$LOGFILE"
+
+log "python $*"
+python "$@" || log "Error running python $*"
+
+log "End."

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -17,6 +17,13 @@ use tokio::process::Command;
 //
 pub fn get_os_specific_command(command: &str, app: &AppHandle) -> Result<Command> {
     let os_specific_command = match command {
+        "python" => {
+            if cfg!(windows) {
+                return Err(anyhow!("Python not supported on Windows yet"));
+            } else {
+                "python"
+            }
+        }
         "uvx" => {
             if cfg!(windows) {
                 "uvx.exe"
@@ -24,11 +31,25 @@ pub fn get_os_specific_command(command: &str, app: &AppHandle) -> Result<Command
                 "uvx"
             }
         }
+        "node" => {
+            if cfg!(windows) {
+                "node.cmd"
+            } else {
+                "node"
+            }
+        }
         "npx" => {
             if cfg!(windows) {
                 "npx.cmd"
             } else {
                 "npx"
+            }
+        }
+        "bunx" => {
+            if cfg!(windows) {
+                "bunx.cmd"
+            } else {
+                "bunx"
             }
         }
         _ => return Err(anyhow!("{} servers not supported.", command)),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,8 +38,11 @@
             "signingIdentity": null
         },
         "resources": {
+            "python": "python",
             "uvx": "uvx",
+            "node": "node",
             "npx": "npx",
+            "bunx": "bunx",
             "build/platform/windows/bin/*": ""
         },
         "shortDescription": "",


### PR DESCRIPTION
Adds support for MCP servers using the following commands:

- `python`
- `node`
- `bunx`

Python and Node are useful for folks developing servers locally and `bunx` is just another package manager some folks like to use.

> [!NOTE]
> I'm not sure how to do Python on Windows yet, so it doesn't get it. Sorry Windows.