### PR TITLE
Handle missing Engines and Models

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,7 @@
     "tabWidth": 4,
     "semi": true,
     "trailingComma": "es5",
-    "printWidth": 100,
+    "printWidth": 80,
     "plugins": [
         "prettier-plugin-svelte",
         "prettier-plugin-tailwindcss"

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -4,6 +4,7 @@ import type { ClientInit, HandleClientError } from '@sveltejs/kit';
 import { goto } from '$app/navigation';
 
 import { setupDeeplinks } from '$lib/deeplinks';
+import { error } from '$lib/logger';
 import { info } from '$lib/logger';
 import App from '$lib/models/app';
 import Config from '$lib/models/config';
@@ -47,8 +48,14 @@ export const init: ClientInit = async () => {
         StartupCheck.UpdateAvailable,
         async () => await isUpToDate(),
     );
+
+    await startup.addCheck(
+        StartupCheck.NoModels,
+        async () => Engine.all().flatMap(e => e.models).length > 0,
+    );
 };
 
-export const handleError: HandleClientError = async () => {
+export const handleError: HandleClientError = async ({ error: err }) => {
+    error(err);
     goto('/error');
 };

--- a/src/lib/engines/ollama/client.ts
+++ b/src/lib/engines/ollama/client.ts
@@ -57,7 +57,9 @@ export default class Ollama implements Client {
     async models(): Promise<IModel[]> {
         const models = (await this.client.list()).models;
 
-        return Promise.all(models.map(async (model) => await this.info(model.name)));
+        return Promise.all(
+            models.map(async (model) => await this.info(model.name))
+        );
     }
 
     async info(name: string): Promise<IModel> {

--- a/src/lib/models/engine.ts
+++ b/src/lib/models/engine.ts
@@ -23,36 +23,58 @@ export default class Engine extends BareModel<IEngine>() {
 
         if (Setting.OllamaUrl) {
             const client = new Ollama(Setting.OllamaUrl);
+            let models: IModel[] = [];
+
+            try {
+                models = (await client.models()).sortBy<IModel>('name');
+            } catch {
+                // noop
+            }
 
             this.add({
                 id: 'ollama',
                 name: 'Ollama',
                 client,
-                models: (await client.models()).sortBy('name'),
+                models,
             });
         }
 
         if (Setting.OpenAIKey) {
             const client = new OpenAI({ apiKey: Setting.OpenAIKey });
+            let models: IModel[] = [];
+
+            try {
+                models = (await client.models()).sortBy('name');
+            } catch {
+                // noop
+            }
 
             this.add({
                 id: 'openai',
                 name: 'OpenAI',
                 client,
-                models: (await client.models()).sortBy('name'),
+                models,
             });
         }
 
         if (Setting.GeminiApiKey) {
             const client = new Gemini({ apiKey: Setting.GeminiApiKey });
+            let models: IModel[] = [];
+
+            try {
+                models = (await client.models()).sortBy('name');
+            } catch {
+                // noop
+            }
 
             this.add({
                 id: 'gemini',
                 name: 'Gemini',
                 client,
-                models: (await client.models()).sortBy('name'),
+                models,
             });
         }
+
         Model.reset(this.all().flatMap((engine) => engine.models));
     }
 }

--- a/src/lib/startup.ts
+++ b/src/lib/startup.ts
@@ -1,9 +1,8 @@
 import { info } from '$lib/logger';
 
 export enum StartupCheck {
-    Ollama = 'ollama',
     Agreement = 'agreement',
-    MissingModels = 'missing-models',
+    NoModels = 'no-models',
     UpdateAvailable = 'update-available',
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,11 +7,14 @@
     import Svg from '$components/Svg.svelte';
     import Updater from '$components/Updater.svelte';
     import Welcome from '$components/Welcome.svelte';
-    import startup, { type Condition, type OnSuccess, StartupCheck } from '$lib/startup';
+    import startup, {
+        type Condition,
+        type OnSuccess,
+        StartupCheck,
+    } from '$lib/startup';
 
     const messages = {
-        [StartupCheck.Ollama]: 'Cannot connect to Ollama',
-        [StartupCheck.MissingModels]: 'Ollama has no models',
+        [StartupCheck.NoModels]: 'No Engines Connected',
         [StartupCheck.Agreement]: 'Non Agreement',
         [StartupCheck.UpdateAvailable]: 'Update Available',
     };
@@ -70,6 +73,9 @@
             {/if}
         </Modal>
     {:else}
-        <Svg name="Logo" class="text-dark fixed top-[50%] left-[50%] h-32 w-32 -translate-[50%]" />
+        <Svg
+            name="Logo"
+            class="text-dark fixed top-[50%] left-[50%] h-32 w-32 -translate-[50%]"
+        />
     {/if}
 </Layout>

--- a/src/routes/chat/[session_id]/+page.svelte
+++ b/src/routes/chat/[session_id]/+page.svelte
@@ -20,11 +20,14 @@
     import Session, { type ISession } from '$lib/models/session';
 
     const session: ISession = $derived(Session.find(page.params.session_id));
-    const model: IModel | undefined = $derived(Model.find(session.config.model));
+    const model: IModel | undefined = $derived(
+        Model.find(session.config.model)
+    );
 
     const sessions: ISession[] = $derived(Session.all());
     const mcpServers: IMcpServer[] = $derived(McpServer.all());
     const engines: IEngine[] = $derived(Engine.all());
+    const hasModels = $derived(engines.flatMap((e) => e.models).length > 0);
 
     let advancedIsOpen = $state(false);
 
@@ -99,7 +102,9 @@
 </script>
 
 {#snippet titlebar()}
-    <Flex class="border-r-light z-10 h-full w-[300px] items-center border-r px-8 pr-4">
+    <Flex
+        class="border-r-light z-10 h-full w-[300px] items-center border-r px-8 pr-4"
+    >
         <h1 class="grow font-[500]">Chat</h1>
         <button
             onclick={() => addSession()}
@@ -113,14 +118,18 @@
 
 <Layout {titlebar}>
     <Flex class="h-full items-start">
-        <Flex class="border-light bg-medium h-content w-[300px] flex-col overflow-auto border-r">
+        <Flex
+            class="border-light bg-medium h-content w-[300px] flex-col overflow-auto border-r"
+        >
             {#each sessions as sess (sess.id)}
                 <Flex
                     class={`text-medium border-b-light w-full justify-between border-b 
                     border-l-transparent text-sm ${sess.id == session?.id ? '!border-l-purple border-l' : ''}`}
                 >
                     <Menu items={menuItems(sess)}>
-                        <Deleteable ondelete={async () => await deleteSession(sess)}>
+                        <Deleteable
+                            ondelete={async () => await deleteSession(sess)}
+                        >
                             <Link
                                 href={`/chat/${sess.id}`}
                                 class="w-full py-3 pl-8 text-left"
@@ -136,13 +145,17 @@
         </Flex>
 
         {#if session}
-            <Flex class="bg-medium h-full w-[calc(100%-600px)] grow items-start">
+            <Flex
+                class="bg-medium h-full w-[calc(100%-600px)] grow items-start"
+            >
                 {#key session.id}
                     <Chat {session} bind:model={session.config.model} />
                 {/key}
             </Flex>
 
-            <Flex class="bg-medium border-light h-full w-[300px] flex-col items-start border-l p-4">
+            <Flex
+                class="bg-medium border-light h-full w-[300px] flex-col items-start border-l p-4"
+            >
                 {#key session.config.model}
                     <ModelMenu
                         {engines}
@@ -151,7 +164,14 @@
                     />
                 {/key}
 
-                {#if !model}
+                {#if !hasModels}
+                    <Flex class="text-red mb-8 w-full justify-center gap-2">
+                        <Svg class="h-6 w-6" name="Warning" />
+                        No engines connected
+                    </Flex>
+                {/if}
+
+                {#if hasModels && !model}
                     <Flex class="text-red mb-8 w-full justify-center gap-2">
                         <Svg class="h-6 w-6" name="Warning" />
                         Model no longer exists
@@ -170,8 +190,10 @@
                         <Flex class="text-light z-0 mb-4 ml-2">
                             <Toggle
                                 label={server.name}
-                                value={Session.hasMcpServer(session, server.name) &&
-                                model?.supportsTools
+                                value={Session.hasMcpServer(
+                                    session,
+                                    server.name
+                                ) && model?.supportsTools
                                     ? 'on'
                                     : 'off'}
                                 disabled={!model?.supportsTools}
@@ -187,12 +209,19 @@
                         class="text-dark mb-4 ml-2 self-start text-sm font-medium hover:cursor-pointer"
                         onclick={() => toggleAdvanced()}
                     >
-                        Advanced <span class="ml-4">{advancedIsOpen ? '⏷' : '⏵'}</span>
+                        Advanced <span class="ml-4"
+                            >{advancedIsOpen ? '⏷' : '⏵'}</span
+                        >
                     </button>
 
                     {#if advancedIsOpen}
-                        <Flex class="m-auto w-full flex-col items-start px-4 pt-4 pl-0">
-                            <label for="ctx_num" class="text-medium mb-1 ml-2 text-sm">
+                        <Flex
+                            class="m-auto w-full flex-col items-start px-4 pt-4 pl-0"
+                        >
+                            <label
+                                for="ctx_num"
+                                class="text-medium mb-1 ml-2 text-sm"
+                            >
                                 Context Window Size
                             </label>
                             <input
@@ -205,7 +234,10 @@
                                 bind:value={session.config.contextWindow}
                             />
 
-                            <label for="temperature" class="text-medium mt-4 mb-1 ml-2 text-sm">
+                            <label
+                                for="temperature"
+                                class="text-medium mt-4 mb-1 ml-2 text-sm"
+                            >
                                 Temperature
                             </label>
 


### PR DESCRIPTION
Now that we have multiple engines, the "Cannot connect to Ollama" no longer makes sense, on it's own, so it was removed.

The problem is that it just explodes now when it can't connect to _anything_.

This change handles startup when no models are present and shows an appropriate error under the model selector in that scenario.

> [!NOTE]
> A lot of this is just prettier formatting.