### PR TITLE
Use `bash` in all runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,10 +71,12 @@ jobs:
 
       - id: version
         name: version
+        shell: bash
         run: echo "version=$(cat src-tauri/tauri.conf.json | jq -r '.version')" >> $GITHUB_OUTPUT
 
       - id: changelog
         name: changelog
+        shell: bash
         run: |
           {
             echo 'changelog<<EOF'


### PR DESCRIPTION
The `version` and `changelog` steps were assuming bash, but not specifying it. That meant they just silently failed on Windows.

Github Windows runners support bash, but you need to explicitly set that. This change does that.