### PR TITLE
Syntax highlighting fallback

### DIFF
--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -10,7 +10,11 @@ export default {
                 },
 
                 code({ text, lang = 'plaintext' }) {
-                    return `<pre><code>${hljs.highlight(text, { language: lang }).value}</code></pre>`;
+                    try {
+                        return `<pre><code>${hljs.highlight(text, { language: lang }).value}</code></pre>`;
+                    } catch {
+                        return `<pre><code>${text}</code></pre>`;
+                    }
                 },
             },
         });


### PR DESCRIPTION
Fallback to just displaying raw code block when syntax highlighting fails.