### PR TITLE
Resync models after Engine change

### DIFF
--- a/src/lib/models/engine.ts
+++ b/src/lib/models/engine.ts
@@ -5,6 +5,7 @@ import Ollama from '$lib/engines/ollama/client';
 import OpenAI from '$lib/engines/openai/client';
 import type { Client, ClientOptions } from '$lib/engines/types';
 import Base, { type ToSqlRow } from '$lib/models/base.svelte';
+import Model from '$lib/models/model';
 
 const AVAILABLE_MODELS: Record<IEngine['type'], 'all' | string[]> = {
     'openai-compat': 'all',
@@ -61,6 +62,11 @@ export default class Engine extends Base<IEngine, Row>('engines') {
         if (Client) {
             return new Client({ ...engine.options, engine });
         }
+    }
+
+    protected static async afterUpdate(engine: IEngine): Promise<IEngine> {
+        await Model.sync();
+        return engine;
     }
 
     protected static async fromSql(row: Row): Promise<IEngine> {

--- a/src/lib/models/session.ts
+++ b/src/lib/models/session.ts
@@ -36,15 +36,19 @@ interface Row {
 }
 
 export default class Session extends Base<ISession, Row>('sessions') {
-    static defaults = () => ({
-        summary: DEFAULT_SUMMARY,
-        config: {
-            model: Model.default().id,
-            contextWindow: 4096,
-            temperature: 0.8,
-            enabledMcpServers: [],
-        },
-    });
+    static defaults = () => {
+        const model = Model.default();
+        return {
+            summary: DEFAULT_SUMMARY,
+            config: {
+                model: model.id,
+                engineId: model.engineId,
+                contextWindow: 4096,
+                temperature: 0.8,
+                enabledMcpServers: [],
+            },
+        };
+    };
 
     static app(session: ISession): IApp | undefined {
         if (!session.appId) return;

--- a/src/routes/chat/[session_id]/+page.ts
+++ b/src/routes/chat/[session_id]/+page.ts
@@ -4,9 +4,12 @@ import type { PageLoad } from './$types';
 
 import { CHAT_APP_ID } from '$lib/const';
 import Config from '$lib/models/config';
+import Model from '$lib/models/model';
 import Session from '$lib/models/session';
 
 export const load: PageLoad = async ({ params }): Promise<void> => {
+    await Model.sync();
+
     if (params.session_id == 'new') {
         const session = await Session.create({ appId: CHAT_APP_ID });
         await goto(`/chat/${session.id}`);


### PR DESCRIPTION
Resyncs all models when an Engine is updated. For example, when you change the Ollama URL between two functioning Ollama instances, we need to fully refetch the list of models it exposes.

This is done via an `afterUpdate` on Engine. That way, anytime an Engine is changed in anyway, we re-fetch all models for all engines.

Also restores the functionality where new Sessions get the user's configured "default" model.