### PR TITLE
Fix missing model error

### DIFF
--- a/src/lib/models/model.ts
+++ b/src/lib/models/model.ts
@@ -18,7 +18,7 @@ export default class Model extends BareModel<IModel>() {
     }
 
     static default(): IModel {
-        return this.find(Config.defaultModel) || Engine.first().models[0];
+        return this.find(Config.defaultModel) || this.first();
     }
 
     static findByOrDefault(params: Partial<IModel>): IModel {


### PR DESCRIPTION
When a User doesn't have Ollama setup AND doesn't have a model favorited, the app attempts to pull the first Engine's first model when creating a new Session.

The problem is that the first Engine is ALWAYS Ollama. If the user doesn't have Ollama setup, it will never resolve and result in an infinite error when the app tries to call `model.id`.

Instead, fallback to the first _Model_, regardless of which Engine is belongs. We should _always_ have at least one model if we're reached this part of the app.