### PR TITLE
Fix Engine Validation

### DIFF
--- a/src/components/Settings/Engine.svelte
+++ b/src/components/Settings/Engine.svelte
@@ -40,7 +40,6 @@
         }
 
         if (engine.type !== 'ollama' && engine.options.apiKey !== '') {
-            console.log(engine.options.apiKey);
             valid = await validateConnected();
         }
 

--- a/src/lib/engines/gemini/client.ts
+++ b/src/lib/engines/gemini/client.ts
@@ -90,6 +90,11 @@ export default class Gemini implements Client {
     }
 
     async connected(): Promise<boolean> {
-        return true; // Assume Gemini is up
+        try {
+            await this.client.models.list();
+            return true;
+        } catch {
+            return false;
+        }
     }
 }

--- a/src/lib/engines/openai/client.ts
+++ b/src/lib/engines/openai/client.ts
@@ -85,6 +85,12 @@ export default class OpenAI implements Client {
     }
 
     async connected(): Promise<boolean> {
-        return (await fetch(new URL(this.options.url).origin, { timeout: 200 })).status == 200;
+        try {
+            const resp = await this.client.models.list().asResponse();
+            const body = await resp.json();
+            return !Object.hasOwn(body, 'error');
+        } catch {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
The validation around whether Tome can connect to and use various Engines wasn't quite right.

For OpenAI-compatible Engines, we now explicitly try to pull a list of Models as a way of determining "connection".

For Gemini, we do the same.

Ollama has not changed.