### PR TITLE
Correctly handle shell arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
         "moment": "^2.30.1",
         "ollama": "^0.5.15",
         "openai": "^4.98.0",
+        "shellwords": "^1.0.1",
         "tailwind-merge": "^3.0.2",
         "uuid4": "^2.0.3"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       openai:
         specifier: ^4.98.0
         version: 4.98.0(ws@8.18.2)(zod@3.25.17)
+      shellwords:
+        specifier: ^1.0.1
+        version: 1.0.1
       tailwind-merge:
         specifier: ^3.0.2
         version: 3.0.2
@@ -2224,6 +2227,9 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shellwords@1.0.1:
+    resolution: {integrity: sha512-Fd5KAbmR0kf6GL4bYJTeHdSKW1mCu6rMxdZcZ4l/hD9wRpBB6RxA01TdmegXWzIhJARyYDFs8EAdnpAsRaDGWw==}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -4610,6 +4616,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shellwords@1.0.1: {}
 
   side-channel-list@1.0.0:
     dependencies:

--- a/src/components/McpServer.svelte
+++ b/src/components/McpServer.svelte
@@ -5,6 +5,7 @@
     import Input from '$components/Input.svelte';
     import Svg from '$components/Svg.svelte';
     import { McpServer } from '$lib/models';
+    import { join, split } from '$lib/shellwords';
 
     interface Props {
         server: McpServer;
@@ -18,15 +19,8 @@
     let key: string = $state('');
     let value: string = $state('');
 
-    $effect.pre(() => {
-        if (server) {
-            command = `${server.command} ${server.args.join(' ')}`.trim();
-            env = Object.entries(server.env);
-        }
-    });
-
     async function save() {
-        const cmd = command.split(' ');
+        const cmd = split(command);
         server.command = cmd[0];
         server.args = cmd.slice(1);
         server.env = Object.fromEntries(env.map(([k, v]) => [constantCase(k), v]));
@@ -44,6 +38,13 @@
         env = env.filter(e => e[0] !== key);
         await save();
     }
+
+    $effect.pre(() => {
+        if (server) {
+            command = `${server.command} ${join(server.args)}`.trim();
+            env = Object.entries(server.env);
+        }
+    });
 </script>
 
 <Flex class="w-full flex-col items-start">

--- a/src/lib/engines/gemini/client.ts
+++ b/src/lib/engines/gemini/client.ts
@@ -63,7 +63,9 @@ export default class Gemini implements Client {
     }
 
     async models(): Promise<IModel[]> {
-        return (await this.client.models.list()).page.map(model => {
+        return (
+            await this.client.models.list({ config: { httpOptions: { timeout: 1000 } } })
+        ).page.map(model => {
             const metadata = model;
             const name = metadata.name?.replace('models/', '') as string;
 

--- a/src/lib/engines/ollama/client.ts
+++ b/src/lib/engines/ollama/client.ts
@@ -3,6 +3,7 @@ import { Ollama as OllamaClient } from 'ollama/browser';
 import OllamaMessage from '$lib/engines/ollama/message';
 import type { Client, ClientProps, Options, Role, Tool } from '$lib/engines/types';
 import { fetch } from '$lib/http';
+import { error } from '$lib/logger';
 import { type IModel, Message } from '$lib/models';
 
 export default class Ollama implements Client {
@@ -80,6 +81,11 @@ export default class Ollama implements Client {
     }
 
     async connected(): Promise<boolean> {
-        return (await fetch(new URL(this.options.url).origin, { timeout: 200 })).status == 200;
+        try {
+            return (await this.models()) && true;
+        } catch (e) {
+            error(e);
+            return false;
+        }
     }
 }

--- a/src/lib/engines/openai/client.ts
+++ b/src/lib/engines/openai/client.ts
@@ -57,7 +57,7 @@ export default class OpenAI implements Client {
     }
 
     async models(): Promise<IModel[]> {
-        return (await this.client.models.list()).data.map(model => {
+        return (await this.client.models.list({ timeout: 1000 })).data.map(model => {
             const { id, ...metadata } = model;
             const name = id.replace('models/', ''); // Gemini model ids are prefixed with "model/"
 

--- a/src/lib/models/model.ts
+++ b/src/lib/models/model.ts
@@ -1,5 +1,5 @@
 import { Config, Engine } from '$lib/models';
-import { BareModel } from '$lib/models';
+import BareModel from '$lib/models/bare.svelte';
 
 export interface IModel {
     id: string;

--- a/src/lib/shellwords.ts
+++ b/src/lib/shellwords.ts
@@ -1,0 +1,5 @@
+export * from 'shellwords';
+
+export function join(args: string[]): string {
+    return args.map(arg => (arg.includes(' ') ? `"${arg}"` : arg)).join(' ');
+}


### PR DESCRIPTION
Previously on, Silly Decisions in Tome™:

I was "parsing" the CLI command for MCP servers by just splitting on spaces. This doesn't work if any of your args have spaces in them.

```
npx whatever --thing 'this is one arg'
```

becomes

```
["npx", "whatever", "--thing", "'this", "is", "one", "arg'"]
```

This change fixes that by using an actual shell command parsing library to handle quoted/spaced arguments correctly.

It also fixes some miscellaneous issues with Engine clients.