### PR TITLE
feat(mcp): Updating mcp area to allow renaming entries

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -76,3 +76,14 @@ pub async fn stop_session(session_id: i32, state: tauri::State<'_, State>) -> Re
 pub fn restart(app: AppHandle) {
     app.restart();
 }
+
+#[tauri::command]
+pub async fn rename_mcp_server(
+    session_id: i32,
+    old_name: String,
+    new_name: String,
+    state: tauri::State<'_, State>,
+) -> Result<(), String> {
+    println!("-> rename_mcp_server({}, {} -> {})", session_id, old_name, new_name);
+    ok_or_err!(mcp::rename_server(session_id, old_name, new_name, state).await)
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -86,6 +86,7 @@ fn main() {
             commands::call_mcp_tool,
             commands::start_mcp_server,
             commands::stop_mcp_server,
+            commands::rename_mcp_server,
             // Sessions
             commands::stop_session,
             // Misc

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -205,3 +205,37 @@ pub async fn peer_info(
     server.kill()?;
     Ok(serde_json::to_string(&peer_info)?)
 }
+
+pub async fn rename_server(
+    session_id: i32,
+    old_name: String,
+    new_name: String,
+    state: tauri::State<'_, State>,
+) -> Result<()> {
+    let mut sessions = state.sessions.lock().await;
+    
+    if let Some(session) = sessions.get_mut(&session_id) {
+        if let Some(server) = session.mcp_servers.get_mut(&old_name) {
+            // Update the server's name
+            server.set_name(new_name.clone());
+            
+            // Update the tools mapping
+            let tools_to_update: Vec<String> = session.tools
+                .iter()
+                .filter(|(_, server_name)| *server_name == &old_name)
+                .map(|(tool_name, _)| tool_name.clone())
+                .collect();
+                
+            for tool_name in tools_to_update {
+                session.tools.insert(tool_name, new_name.clone());
+            }
+            
+            // Move the server to the new name in the map
+            if let Some(server) = session.mcp_servers.remove(&old_name) {
+                session.mcp_servers.insert(new_name, server);
+            }
+        }
+    }
+    
+    Ok(())
+}

--- a/src-tauri/src/mcp/server.rs
+++ b/src-tauri/src/mcp/server.rs
@@ -18,6 +18,7 @@ type Service = RunningService<RoleClient, ()>;
 pub struct McpServer {
     service: Service,
     pid: Pid,
+    custom_name: Option<String>,
 }
 
 impl McpServer {
@@ -34,11 +35,19 @@ impl McpServer {
         let proc = McpProcess::start(command, args, env, app)?;
         let pid = proc.pid();
         let service = ().serve(proc).await?;
-        Ok(Self { service, pid })
+        Ok(Self { 
+            service, 
+            pid,
+            custom_name: None,
+        })
     }
 
     pub fn name(&self) -> String {
-        self.peer_info().server_info.name
+        self.custom_name.clone().unwrap_or_else(|| self.peer_info().server_info.name)
+    }
+
+    pub fn set_name(&mut self, new_name: String) {
+        self.custom_name = Some(new_name);
     }
 
     pub fn peer_info(&self) -> <RoleClient as ServiceRole>::PeerInfo {

--- a/src/lib/models/model.ts
+++ b/src/lib/models/model.ts
@@ -1,5 +1,5 @@
 import { Config, Engine } from '$lib/models';
-import { BareModel } from '$lib/models';
+import BareModel from '$lib/models/bare.svelte';
 
 export interface IModel {
     id: string;

--- a/src/lib/models/model.ts
+++ b/src/lib/models/model.ts
@@ -1,5 +1,5 @@
 import { Config, Engine } from '$lib/models';
-import BareModel from '$lib/models/bare.svelte';
+import { BareModel } from '$lib/models';
 
 export interface IModel {
     id: string;

--- a/src/routes/mcp-servers/+layout.svelte
+++ b/src/routes/mcp-servers/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
+    import { invoke } from '@tauri-apps/api/core';
 
     import Deleteable from '$components/Deleteable.svelte';
     import Flex from '$components/Flex.svelte';
@@ -27,14 +28,34 @@
         },
     ];
 
+    let isRenaming = $state(false);
+    let newName = $state('');
+    let renamingServer: McpServer | null = $state(null);
+
     function items(server: McpServer): MenuItem[] {
         return [
+            {
+                label: 'Rename',
+                onclick: () => {
+                    newName = server.name;
+                    renamingServer = server;
+                    isRenaming = true;
+                }
+            },
             {
                 label: 'Delete',
                 style: 'text-red hover:bg-red hover:text-white',
                 onclick: async () => await destroy(server),
             },
         ];
+    }
+
+    async function handleRename() {
+        if (renamingServer && newName && newName !== renamingServer.name) {
+            await renamingServer.rename(newName);
+        }
+        isRenaming = false;
+        renamingServer = null;
     }
 
     async function destroy(server: McpServer) {
@@ -62,13 +83,29 @@
 {#snippet McpServerView(server: McpServer)}
     <Menu items={items(server)}>
         <Deleteable ondelete={() => destroy(server)}>
-            <Link
-                href={`/mcp-servers/${server.id}`}
-                class="w-full py-3 pl-8 text-sm hover:cursor-pointer"
-                activeClass="text-purple border-l border-l-purple"
-            >
-                {server.name}
-            </Link>
+            {#if isRenaming && renamingServer?.id === server.id}
+                <form
+                    class="w-full py-3 pl-8"
+                    onsubmit={e => { e.preventDefault(); handleRename(); }}
+                >
+                    <input
+                        type="text"
+                        bind:value={newName}
+                        class="w-full bg-transparent text-sm outline-none"
+                        onblur={handleRename}
+                        onkeydown={e => e.stopPropagation()}
+                        autofocus
+                    />
+                </form>
+            {:else}
+                <Link
+                    href={`/mcp-servers/${server.id}`}
+                    class="w-full py-3 pl-8 text-sm hover:cursor-pointer"
+                    activeClass="text-purple border-l border-l-purple"
+                >
+                    {server.name}
+                </Link>
+            {/if}
         </Deleteable>
     </Menu>
 {/snippet}


### PR DESCRIPTION
Small change that adds a 'rename' button to the list of mcp entries.

![Screenshot 2025-06-11 at 2 40 29 PM](https://github.com/user-attachments/assets/ebcd9bf5-db04-44be-b8ca-550275d45958)
