### PR TITLE
Adds error handling around adding new mcp servers

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Tome"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src/components/Button.svelte
+++ b/src/components/Button.svelte
@@ -1,13 +1,42 @@
 <script lang="ts">
     import type { HTMLButtonAttributes } from 'svelte/elements';
+    import type {} from 'svelte/events';
     import { twMerge } from 'tailwind-merge';
 
-    const { children, class: cls = '', ...rest }: HTMLButtonAttributes = $props();
+    import Spinner from '$components/Spinner.svelte';
+    import type { ButtonEvent } from '$lib/types';
+
+    interface Props extends HTMLButtonAttributes {
+        spinner?: boolean;
+    }
+
+    const {
+        children,
+        class: cls = '',
+        spinner = true,
+        onclick: _onclick,
+        ...rest
+    }: Props = $props();
+
+    let waiting = $state(false);
+
+    async function onclick(e: ButtonEvent) {
+        if (_onclick) {
+            waiting = true;
+            await _onclick(e);
+            waiting = false;
+        }
+    }
 </script>
 
-<button
-    class={twMerge('rounded-md border p-2 px-6 text-sm hover:cursor-pointer', cls?.toString())}
-    {...rest}
->
-    {@render children?.()}
-</button>
+{#if waiting && spinner}
+    <Spinner />
+{:else}
+    <button
+        class={twMerge('rounded-md border p-2 px-6 text-sm hover:cursor-pointer', cls?.toString())}
+        {onclick}
+        {...rest}
+    >
+        {@render children?.()}
+    </button>
+{/if}

--- a/src/components/McpServer.svelte
+++ b/src/components/McpServer.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
     import { constantCase } from 'change-case';
+    import { goto } from '$app/navigation';
+
+    import Button from './Button.svelte';
 
     import Flex from '$components/Flex.svelte';
     import Input from '$components/Input.svelte';
@@ -19,17 +22,47 @@
     let key: string = $state('');
     let value: string = $state('');
 
+    let error: string | null = $state(null);
+
     async function save() {
+        error = null;
+
+        if (command == '') {
+            return;
+        }
+
         const cmd = split(command);
         server.command = cmd[0];
         server.args = cmd.slice(1);
         server.env = Object.fromEntries(env.map(([k, v]) => [constantCase(k), v]));
-        server = await server.save();
+
+        try {
+            server = await server.save();
+            goto(`/mcp-servers/${server.id}`);
+        } catch (e) {
+            if (e instanceof Error) {
+                error = e.message;
+            }
+
+            if (typeof e == 'string') {
+                if (e.includes('initialize response')) {
+                    error = 'mcp server could not initialize';
+                } else {
+                    error = e;
+                }
+            }
+            return;
+        }
+    }
+
+    async function update() {
+        if (server.id) {
+            await save();
+        }
     }
 
     async function addEnv() {
         env.push([key, value]);
-        await save();
         key = '';
         value = '';
     }
@@ -48,45 +81,67 @@
 </script>
 
 <Flex class="w-full flex-col items-start">
-    <h1 class="text-purple mb-4 ml-4 text-2xl">{server?.name}</h1>
+    {#if server?.id}
+        <h1 class="text-purple mb-8 ml-4 text-2xl">{server.name}</h1>
+    {:else}
+        <h1 class="text-light mb-8 ml-4 text-2xl">Add Server</h1>
+    {/if}
 
-    <h2 class="text-medium mt-8 mb-4 ml-4 text-xl">Command</h2>
+    <h2 class="text-medium mb-4 ml-4 text-xl">Command</h2>
+
     <Input
         bind:value={command}
         label={false}
         name="command"
         class="w-full"
-        onchange={save}
+        onchange={update}
         placeholder="uvx | npx COMMAND [args]"
     />
 
-    <h2 class="text-medium mt-8 mb-4 ml-4 text-xl">ENV</h2>
-    <Flex class="grid w-full auto-cols-max auto-rows-max grid-cols-2 gap-4">
-        {#each env, i (i)}
+    <Flex class="mt-8 mb-4 ml-4 items-center">
+        <h2 class="text-medium text-lg">ENV</h2>
+        <button class="border-light ml-4 h-6 w-6 rounded-md border">
+            <p class="text-medium h-6 w-6 pr-0.5 text-center text-[12px] !leading-[18px]">+</p>
+        </button>
+    </Flex>
+
+    {#each env, i (i)}
+        <Flex class="mb-4 w-full gap-4">
             <Input
-                onchange={save}
+                onchange={update}
                 label={false}
                 placeholder="Key"
                 bind:value={env[i][0]}
                 class="uppercase"
             />
 
-            <Flex>
-                <Input onchange={save} label={false} placeholder="Value" bind:value={env[i][1]} />
-                <button
-                    class="text-dark hover:text-red ml-4 transition duration-300 hover:cursor-pointer"
-                    onclick={() => remove(env[i][0])}
-                >
-                    <Svg name="Delete" class="h-4 w-4" />
-                </button>
-            </Flex>
-        {/each}
+            <Input onchange={update} label={false} placeholder="Value" bind:value={env[i][1]} />
 
-        <Input bind:value={key} label={false} placeholder="Key" class="uppercase" />
-
-        <Flex>
-            <Input bind:value onchange={addEnv} label={false} placeholder="Value" />
-            <div class="ml-4 h-4 w-4"></div>
+            <button
+                class="text-dark hover:text-red ml-4 transition duration-300 hover:cursor-pointer"
+                onclick={() => remove(env[i][0])}
+            >
+                <Svg name="Delete" class="h-4 w-4" />
+            </button>
         </Flex>
+    {/each}
+
+    <Flex class="mb-8 w-full gap-4">
+        <Input bind:value={key} label={false} placeholder="Key" class="uppercase" />
+        <Input bind:value onchange={addEnv} label={false} placeholder="Value" />
+        <div class="w-16"></div>
     </Flex>
+
+    {#if !server?.id}
+        <Flex class="w-full">
+            <Button class="border-purple text-purple" onclick={save}>Save</Button>
+
+            {#if error}
+                <Flex class="text-red ml-4">
+                    <Svg name="Warning" class="mr-2 h-4 w-4" />
+                    {error}
+                </Flex>
+            {/if}
+        </Flex>
+    {/if}
 </Flex>

--- a/src/components/Spinner.svelte
+++ b/src/components/Spinner.svelte
@@ -20,7 +20,7 @@
         position: absolute;
         inset: 0px;
         border-radius: 50%;
-        border: 5px solid #fff;
+        border: 3px solid #fff;
         animation: prixClipFix 2s linear infinite;
     }
 

--- a/src/lib/engines/ollama/client.ts
+++ b/src/lib/engines/ollama/client.ts
@@ -3,7 +3,6 @@ import { Ollama as OllamaClient } from 'ollama/browser';
 import OllamaMessage from '$lib/engines/ollama/message';
 import type { Client, ClientProps, Options, Role, Tool } from '$lib/engines/types';
 import { fetch } from '$lib/http';
-import { error } from '$lib/logger';
 import { type IModel, Message } from '$lib/models';
 
 export default class Ollama implements Client {
@@ -83,8 +82,7 @@ export default class Ollama implements Client {
     async connected(): Promise<boolean> {
         try {
             return (await this.models()) && true;
-        } catch (e) {
-            error(e);
+        } catch {
             return false;
         }
     }

--- a/src/lib/models/mcp-server.svelte.ts
+++ b/src/lib/models/mcp-server.svelte.ts
@@ -80,20 +80,21 @@ export default class McpServer extends Base<Row>('mcp_servers') {
         });
     }
 
-    async afterCreate() {
-        this.metadata = JSON.parse(
+    async beforeCreate(row: Row): Promise<ToSqlRow<Row>> {
+        const metadata: Metadata = JSON.parse(
             await invoke('get_metadata', {
-                command: this.command,
-                args: this.args,
-                env: this.env,
+                command: row.command,
+                args: JSON.parse(row.args),
+                env: JSON.parse(row.env),
             })
         );
 
-        this.name = this.metadata?.serverInfo?.name
+        row.metadata = JSON.stringify(metadata);
+        row.name = metadata.serverInfo?.name
             ?.replace('mcp-server/', '')
             ?.replace('/', '-') as string;
 
-        await this.save();
+        return row;
     }
 
     static async fromSql(row: Row): Promise<McpServer> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,7 @@
 export interface CheckboxEvent extends Event {
     currentTarget: EventTarget & HTMLInputElement;
 }
+
+export interface ButtonEvent extends MouseEvent {
+    currentTarget: EventTarget & HTMLButtonElement;
+}


### PR DESCRIPTION
Adds error handling when you're trying to add a new MCP server.

This changes the UX to use an explicit "save" button for new mcp servers instead of the auto-save thing we had before. It was too hard to determine when you needed to try to save/vallidate/etc. Now it's explicit.

### Invalid Command (not `npx`, `uvx`, etc)
<img width="1012" alt="image" src="https://github.com/user-attachments/assets/7d0eb0a0-2285-4e55-8590-dddfa37a872d" />

### Server Doesn't Start Properly ("initiallize" is a specific phase in the mcp spec)
<img width="1012" alt="image" src="https://github.com/user-attachments/assets/7879e249-28c3-462c-828a-7b91f376d4cf" />
