### PR TITLE
feature(mcp): Adding streamable mcp

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tokio",
+ "tokio-stream",
  "webview2-com 0.37.0",
  "webview2-com-sys 0.37.0",
  "windows 0.61.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ rmcp = { version = "0.1.5", features = [
   "transport-child-process",
 ] }
 tokio = "1.29.1"
+tokio-stream = "0.1"
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }
 sysinfo = { version = "0.34.2", features = ["windows"] }
 tauri-plugin-single-instance = { version = "2.0.0", features = ["deep-link"] }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -20,9 +20,13 @@ pub async fn get_metadata(
     command: String,
     args: Vec<String>,
     env: HashMap<String, String>,
+    transport_type: Option<String>,
+    transport_config: Option<serde_json::Value>,
     app: AppHandle,
 ) -> Result<String, String> {
-    ok_or_err!(mcp::peer_info(command, args, env, app).await)
+    let transport_type = transport_type.unwrap_or_else(|| "stdio".to_string());
+    let transport_config = transport_config.unwrap_or_else(|| serde_json::json!({}));
+    ok_or_err!(mcp::peer_info(command, args, env, transport_type, transport_config, app).await)
 }
 
 #[tauri::command]
@@ -31,10 +35,14 @@ pub async fn start_mcp_server(
     command: String,
     args: Vec<String>,
     env: HashMap<String, String>,
+    transport_type: Option<String>,
+    transport_config: Option<serde_json::Value>,
     app: AppHandle,
 ) -> Result<(), String> {
     println!("-> start_mcp_server({}, {})", session_id, command);
-    ok_or_err!(mcp::start(session_id, command, args, env, app).await)
+    let transport_type = transport_type.unwrap_or_else(|| "stdio".to_string());
+    let transport_config = transport_config.unwrap_or_else(|| serde_json::json!({}));
+    ok_or_err!(mcp::start(session_id, command, args, env, transport_type, transport_config, app).await)
 }
 
 #[tauri::command]

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -1,5 +1,6 @@
 pub(crate) mod process;
 pub(crate) mod server;
+pub(crate) mod http;
 
 use std::collections::HashMap;
 
@@ -104,11 +105,13 @@ pub async fn start(
     command: String,
     args: Vec<String>,
     env: HashMap<String, String>,
+    transport_type: String,
+    transport_config: serde_json::Value,
     app: AppHandle,
 ) -> Result<()> {
     let handle = app.clone();
     let state = handle.state::<State>();
-    let server = McpServer::start(command, args, env, app).await?;
+    let server = McpServer::start(command, args, env, transport_type, transport_config, app).await?;
 
     let mut sessions = state.sessions.lock().await;
     let mut session = sessions.remove(&session_id).unwrap_or_default();
@@ -198,9 +201,11 @@ pub async fn peer_info(
     command: String,
     args: Vec<String>,
     env: HashMap<String, String>,
+    transport_type: String,
+    transport_config: serde_json::Value,
     app: AppHandle,
 ) -> Result<String> {
-    let server = McpServer::start(command, args, env, app).await?;
+    let server = McpServer::start(command, args, env, transport_type, transport_config, app).await?;
     let peer_info = server.peer_info();
     server.kill()?;
     Ok(serde_json::to_string(&peer_info)?)

--- a/src-tauri/src/mcp/http.rs
+++ b/src-tauri/src/mcp/http.rs
@@ -1,0 +1,399 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use futures::stream::{BoxStream, StreamExt};
+use futures::sink::SinkExt;
+use futures::{Sink, Stream};
+use reqwest::{Client, Response};
+use rmcp::service::{RxJsonRpcMessage, ServiceRole, TxJsonRpcMessage};
+use rmcp::transport::IntoTransport;
+use serde_json::{json, Value};
+use tokio::sync::{mpsc, Mutex};
+use tokio::time::timeout;
+
+#[derive(Debug, Clone)]
+pub struct HttpTransportConfig {
+    pub url: String,
+    pub timeout: Duration,
+    pub retries: u32,
+    pub session_id: Option<String>,
+    pub headers: HashMap<String, String>,
+}
+
+impl Default for HttpTransportConfig {
+    fn default() -> Self {
+        Self {
+            url: String::new(),
+            timeout: Duration::from_secs(30),
+            retries: 3,
+            session_id: None,
+            headers: HashMap::new(),
+        }
+    }
+}
+
+pub struct HttpTransport {
+    config: Arc<Mutex<HttpTransportConfig>>,
+    client: Client,
+}
+
+impl HttpTransport {
+    pub fn new(config: HttpTransportConfig) -> Self {
+        let client = Client::builder()
+            .timeout(config.timeout)
+            .build()
+            .expect("Failed to create HTTP client");
+
+        Self { 
+            config: Arc::new(Mutex::new(config)), 
+            client 
+        }
+    }
+
+    pub async fn get_session_id(&self) -> Option<String> {
+        let config = self.config.lock().await;
+        config.session_id.clone()
+    }
+
+    pub async fn initialize_session(&self) -> Result<()> {
+        let mut config = self.config.lock().await;
+        
+        // Send initialize request
+        let init_request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {
+                    "tools": {}
+                },
+                "clientInfo": {
+                    "name": "tome",
+                    "version": "0.9.0"
+                }
+            }
+        });
+
+        let response = self.send_request_with_config(&config, init_request).await?;
+        
+        // Extract session ID from response headers
+        if let Some(session_id) = response.headers().get("Mcp-Session-Id") {
+            if let Ok(session_id_str) = session_id.to_str() {
+                config.session_id = Some(session_id_str.to_string());
+                log::info!("HTTP MCP session initialized with ID: {}", session_id_str);
+            }
+        }
+
+        // Send initialized notification
+        let initialized_notification = json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        });
+
+        self.send_request_with_config(&config, initialized_notification).await?;
+        Ok(())
+    }
+
+    async fn send_request_with_config(&self, config: &HttpTransportConfig, body: Value) -> Result<Response> {
+        let mut request = self.client
+            .post(&config.url)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream");
+
+        // Add session ID header if present
+        if let Some(session_id) = &config.session_id {
+            request = request.header("Mcp-Session-Id", session_id);
+        }
+
+        // Add custom headers
+        for (key, value) in &config.headers {
+            request = request.header(key, value);
+        }
+
+        let response = request.json(&body).send().await?;
+
+        if !response.status().is_success() {
+            return Err(anyhow!("HTTP request failed with status: {}", response.status()));
+        }
+
+        Ok(response)
+    }
+
+    async fn send_request(&self, body: Value) -> Result<Response> {
+        let config = self.config.lock().await;
+        self.send_request_with_config(&config, body).await
+    }
+
+    async fn handle_sse_stream(&self, response: Response) -> Result<BoxStream<'static, Value>> {
+        let content_type = response.headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+
+        if content_type.contains("text/event-stream") {
+            // Handle SSE stream
+            let mut stream = response.bytes_stream();
+            let (tx, rx) = mpsc::unbounded_channel();
+
+            tokio::spawn(async move {
+                let mut buffer = String::new();
+                
+                while let Some(chunk) = stream.next().await {
+                    match chunk {
+                        Ok(bytes) => {
+                            buffer.push_str(&String::from_utf8_lossy(&bytes));
+                            
+                            // Process complete SSE events
+                            while let Some(event_end) = buffer.find("\n\n") {
+                                let event_data = buffer[..event_end].to_string();
+                                buffer = buffer[event_end + 2..].to_string();
+                                
+                                if let Some(json_data) = Self::parse_sse_event(&event_data) {
+                                    if let Ok(value) = serde_json::from_str::<Value>(&json_data) {
+                                        if tx.send(value).is_err() {
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        Err(_) => break,
+                    }
+                }
+            });
+
+            Ok(Box::pin(tokio_stream::wrappers::UnboundedReceiverStream::new(rx)))
+        } else {
+            // Handle single JSON response
+            let json: Value = response.json().await?;
+            let (tx, rx) = mpsc::unbounded_channel();
+            let _ = tx.send(json);
+            Ok(Box::pin(tokio_stream::wrappers::UnboundedReceiverStream::new(rx)))
+        }
+    }
+
+    fn parse_sse_event(event_data: &str) -> Option<String> {
+        for line in event_data.lines() {
+            if let Some(data) = line.strip_prefix("data: ") {
+                return Some(data.to_string());
+            }
+        }
+        None
+    }
+}
+
+pub struct HttpTransportSink {
+    config: Arc<Mutex<HttpTransportConfig>>,
+    client: Client,
+}
+
+impl HttpTransportSink {
+    pub fn new(config: Arc<Mutex<HttpTransportConfig>>) -> Self {
+        let client = Client::builder()
+            .build()
+            .expect("Failed to create HTTP client");
+
+        Self { config, client }
+    }
+}
+
+impl<R: ServiceRole> Sink<TxJsonRpcMessage<R>> for HttpTransportSink {
+    type Error = std::io::Error;
+
+    fn poll_ready(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn start_send(
+        self: std::pin::Pin<&mut Self>,
+        item: TxJsonRpcMessage<R>,
+    ) -> Result<(), Self::Error> {
+        let this = self.get_mut();
+        let json_value = serde_json::to_value(&item)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+        let config = this.config.clone();
+        let client = this.client.clone();
+
+        tokio::spawn(async move {
+            let config_guard = config.lock().await;
+            if let Err(e) = HttpTransport::send_request_static(&client, &config_guard, json_value).await {
+                log::error!("Failed to send HTTP request: {}", e);
+            }
+        });
+
+        Ok(())
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+}
+
+impl HttpTransport {
+    async fn send_request_static(
+        client: &Client,
+        config: &HttpTransportConfig,
+        body: Value,
+    ) -> Result<Response> {
+        let mut request = client
+            .post(&config.url)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream");
+
+        if let Some(session_id) = &config.session_id {
+            request = request.header("Mcp-Session-Id", session_id);
+        }
+
+        for (key, value) in &config.headers {
+            request = request.header(key, value);
+        }
+
+        let response = request.json(&body).send().await?;
+
+        if !response.status().is_success() {
+            return Err(anyhow!("HTTP request failed with status: {}", response.status()));
+        }
+
+        Ok(response)
+    }
+}
+
+pub struct HttpTransportStream {
+    stream: BoxStream<'static, Value>,
+}
+
+impl HttpTransportStream {
+    pub fn new(stream: BoxStream<'static, Value>) -> Self {
+        Self { stream }
+    }
+}
+
+impl<R: ServiceRole> Stream for HttpTransportStream {
+    type Item = RxJsonRpcMessage<R>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        match self.stream.poll_next_unpin(cx) {
+            std::task::Poll::Ready(Some(value)) => {
+                match serde_json::from_value::<RxJsonRpcMessage<R>>(value) {
+                    Ok(message) => std::task::Poll::Ready(Some(message)),
+                    Err(e) => {
+                        log::error!("Failed to deserialize JSON-RPC message: {}", e);
+                        // Continue polling for the next message
+                        cx.waker().wake_by_ref();
+                        std::task::Poll::Pending
+                    }
+                }
+            }
+            std::task::Poll::Ready(None) => std::task::Poll::Ready(None),
+            std::task::Poll::Pending => std::task::Poll::Pending,
+        }
+    }
+}
+
+impl<R: ServiceRole> IntoTransport<R, std::io::Error, ()> for HttpTransport {
+    fn into_transport(
+        self,
+    ) -> (
+        impl Sink<TxJsonRpcMessage<R>, Error = std::io::Error> + Send + 'static,
+        impl Stream<Item = RxJsonRpcMessage<R>> + Send + 'static,
+    ) {
+        let sink = HttpTransportSink::new(self.config.clone());
+        
+        // For the stream, we need to establish a GET connection for SSE
+        let stream_config = self.config.clone();
+        let stream_client = self.client.clone();
+        
+        let (tx, rx) = mpsc::unbounded_channel();
+        
+        tokio::spawn(async move {
+            if let Err(e) = Self::establish_sse_connection(stream_client, stream_config, tx).await {
+                log::error!("Failed to establish SSE connection: {}", e);
+            }
+        });
+        
+        let stream = HttpTransportStream::new(Box::pin(
+            tokio_stream::wrappers::UnboundedReceiverStream::new(rx)
+        ));
+        
+        (sink, stream)
+    }
+}
+
+impl HttpTransport {
+    async fn establish_sse_connection(
+        client: Client,
+        config: Arc<Mutex<HttpTransportConfig>>,
+        tx: mpsc::UnboundedSender<Value>,
+    ) -> Result<()> {
+        let config_guard = config.lock().await;
+        let mut request = client
+            .get(&config_guard.url)
+            .header("Accept", "text/event-stream");
+
+        if let Some(session_id) = &config_guard.session_id {
+            request = request.header("Mcp-Session-Id", session_id);
+        }
+
+        for (key, value) in &config_guard.headers {
+            request = request.header(key, value);
+        }
+        
+        drop(config_guard); // Release the lock before sending the request
+
+        let response = request.send().await?;
+
+        if !response.status().is_success() {
+            return Err(anyhow!("SSE connection failed with status: {}", response.status()));
+        }
+
+        let mut stream = response.bytes_stream();
+        let mut buffer = String::new();
+
+        while let Some(chunk) = stream.next().await {
+            match chunk {
+                Ok(bytes) => {
+                    buffer.push_str(&String::from_utf8_lossy(&bytes));
+                    
+                    while let Some(event_end) = buffer.find("\n\n") {
+                        let event_data = buffer[..event_end].to_string();
+                        buffer = buffer[event_end + 2..].to_string();
+                        
+                        if let Some(json_data) = Self::parse_sse_event(&event_data) {
+                            if let Ok(value) = serde_json::from_str::<Value>(&json_data) {
+                                if tx.send(value).is_err() {
+                                    return Ok(());
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    log::error!("SSE stream error: {}", e);
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src-tauri/src/mcp/server.rs
+++ b/src-tauri/src/mcp/server.rs
@@ -19,7 +19,7 @@ type Service = RunningService<RoleClient, ()>;
 #[derive(Debug)]
 pub enum McpTransport {
     Stdio { pid: Pid },
-    Http { url: String, session_id: Option<String> },
+    Http { _url: String, _session_id: Option<String> },
 }
 
 #[derive(Debug)]
@@ -82,7 +82,7 @@ impl McpServer {
                 let config = HttpTransportConfig {
                     url: url.clone(),
                     timeout: Duration::from_secs(timeout),
-                    retries,
+                    _retries: retries,
                     session_id: None, // Will be set during initialization
                     headers,
                 };
@@ -99,7 +99,7 @@ impl McpServer {
                 
                 Ok(Self { 
                     service, 
-                    transport: McpTransport::Http { url, session_id },
+                    transport: McpTransport::Http { _url: url, _session_id: session_id },
                     custom_name: None,
                 })
             }

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -278,5 +278,14 @@ CREATE TABLE IF NOT EXISTS tasks_mcp_servers (
             "#,
             kind: MigrationKind::Up,
         },
+        Migration {
+            version: 17,
+            description: "add_mcp_transport_support",
+            sql: r#"
+ALTER TABLE mcp_servers ADD COLUMN transport_type TEXT NOT NULL DEFAULT "stdio";
+ALTER TABLE mcp_servers ADD COLUMN transport_config JSON NOT NULL DEFAULT "{}";
+            "#,
+            kind: MigrationKind::Up,
+        },
     ]
 }

--- a/src/app.css
+++ b/src/app.css
@@ -62,7 +62,7 @@ body {
     color: var(--text-color-light);
 }
 
-html[data-theme="light"] {
+html[data-theme='light'] {
     --color-purple-dark: #7c5fc0;
     --color-purple: #7c5fc0;
     --color-red: #d7263d;
@@ -82,7 +82,7 @@ html[data-theme="light"] {
     --text-color-dark: #bbbbbb;
 }
 
-html[data-theme="dark"] {
+html[data-theme='dark'] {
     --color-purple-dark: #9d7cd8;
     --color-purple: #bb9af7;
     --color-red: #ff757f;
@@ -102,14 +102,14 @@ html[data-theme="dark"] {
     --text-color-dark: #333333;
 }
 
-html[data-theme="light"],
-body[data-theme="light"] {
+html[data-theme='light'],
+body[data-theme='light'] {
     background: var(--background-color-medium);
     color: #222;
 }
 
-html[data-theme="dark"],
-body[data-theme="dark"] {
+html[data-theme='dark'],
+body[data-theme='dark'] {
     background: #0b0b0b;
     color: #fff;
 }

--- a/src/components/Box.svelte
+++ b/src/components/Box.svelte
@@ -7,6 +7,9 @@
     const { children, class: cls = '', ...rest }: SvelteHTMLElements['div'] = $props();
 </script>
 
-<Flex class={twMerge('border-light bg-medium mb-2 rounded-lg border p-4', cls?.toString())} {...rest}>
+<Flex
+    class={twMerge('border-light bg-medium mb-2 rounded-lg border p-4', cls?.toString())}
+    {...rest}
+>
     {@render children?.()}
 </Flex>

--- a/src/components/McpServer.svelte
+++ b/src/components/McpServer.svelte
@@ -7,7 +7,7 @@
     import Flex from '$components/Flex.svelte';
     import Input from '$components/Input.svelte';
     import Svg from '$components/Svg.svelte';
-    import { McpServer } from '$lib/models';
+    import { McpServer, type TransportConfig } from '$lib/models';
     import { join, split } from '$lib/shellwords';
 
     interface Props {
@@ -18,6 +18,15 @@
 
     let command = $state('');
     let env: [string, string][] = $state([]);
+    let transportType = $state('stdio');
+    let transportConfig: TransportConfig = $state({
+        authentication: {
+            type: 'none',
+            token: '',
+            username: '',
+            password: '',
+        },
+    });
 
     let key: string = $state('');
     let value: string = $state('');
@@ -27,14 +36,42 @@
     async function save() {
         error = null;
 
-        if (command == '') {
+        // Validate required fields based on transport type
+        if (transportType === 'stdio' && command === '') {
+            error = 'Command is required for stdio transport';
             return;
         }
 
-        const cmd = split(command);
-        server.command = cmd[0];
-        server.args = cmd.slice(1);
-        server.env = Object.fromEntries(env.map(([k, v]) => [constantCase(k), v]));
+        if (transportType === 'http') {
+            if (!transportConfig.url) {
+                error = 'URL is required for HTTP transport';
+                return;
+            }
+            
+            // Validate URL format
+            try {
+                new URL(transportConfig.url);
+            } catch (e) {
+                error = 'Please enter a valid URL (e.g., https://example.com/mcp)';
+                return;
+            }
+        }
+
+        // Set transport type and config
+        server.transportType = transportType;
+        server.transportConfig = transportConfig;
+
+        if (transportType === 'stdio') {
+            const cmd = split(command);
+            server.command = cmd[0];
+            server.args = cmd.slice(1);
+            server.env = Object.fromEntries(env.map(([k, v]) => [constantCase(k), v]));
+        } else {
+            // For HTTP transport, clear stdio-specific fields
+            server.command = '';
+            server.args = [];
+            server.env = {};
+        }
 
         try {
             server = await server.save();
@@ -72,10 +109,19 @@
         await save();
     }
 
+    function initializeAuth() {
+        if (!transportConfig.authentication) {
+            transportConfig.authentication = { type: 'none' };
+        }
+    }
+
     $effect.pre(() => {
         if (server) {
             command = `${server.command} ${join(server.args)}`.trim();
             env = Object.entries(server.env);
+            transportType = server.transportType || 'stdio';
+            transportConfig = server.transportConfig || {};
+            initializeAuth();
         }
     });
 </script>
@@ -87,50 +133,157 @@
         <h1 class="text-light mb-8 ml-4 text-2xl">Add Server</h1>
     {/if}
 
-    <h2 class="text-medium mb-4 ml-4 text-xl">Command</h2>
-
-    <Input
-        bind:value={command}
-        label={false}
-        name="command"
-        class="w-full"
-        onchange={update}
-        placeholder="uvx | npx COMMAND [args]"
-    />
-
-    <Flex class="mt-8 mb-4 ml-4 items-center">
-        <h2 class="text-medium text-lg">ENV</h2>
-        <button class="border-light ml-4 h-6 w-6 rounded-md border">
-            <p class="text-medium h-6 w-6 pr-0.5 text-center text-[12px] !leading-[18px]">+</p>
-        </button>
+    <!-- Transport Type Selection -->
+    <h2 class="text-medium mb-4 ml-4 text-xl">Transport Type</h2>
+    <Flex class="mb-8 ml-4 gap-8">
+        <label class="flex cursor-pointer items-center">
+            <input
+                type="radio"
+                bind:group={transportType}
+                value="stdio"
+                onchange={update}
+                class="mr-2"
+            />
+            <span class="text-medium">Standard I/O</span>
+        </label>
+        <label class="flex cursor-pointer items-center">
+            <input
+                type="radio"
+                bind:group={transportType}
+                value="http"
+                onchange={update}
+                class="mr-2"
+            />
+            <span class="text-medium">HTTP</span>
+        </label>
     </Flex>
 
-    {#each env, i (i)}
-        <Flex class="mb-4 w-full gap-4">
-            <Input
-                onchange={update}
-                label={false}
-                placeholder="Key"
-                bind:value={env[i][0]}
-                class="uppercase"
-            />
+    {#if transportType === 'stdio'}
+        <!-- Stdio Transport Fields -->
+        <h2 class="text-medium mb-4 ml-4 text-xl">Command</h2>
 
-            <Input onchange={update} label={false} placeholder="Value" bind:value={env[i][1]} />
+        <Input
+            bind:value={command}
+            label={false}
+            name="command"
+            class="w-full"
+            onchange={update}
+            placeholder="uvx | npx COMMAND [args]"
+        />
 
-            <button
-                class="text-dark hover:text-red ml-4 transition duration-300 hover:cursor-pointer"
-                onclick={() => remove(env[i][0])}
-            >
-                <Svg name="Delete" class="h-4 w-4" />
+        <Flex class="mt-8 mb-4 ml-4 items-center">
+            <h2 class="text-medium text-lg">ENV</h2>
+            <button class="border-light ml-4 h-6 w-6 rounded-md border">
+                <p class="text-medium h-6 w-6 pr-0.5 text-center text-[12px] !leading-[18px]">+</p>
             </button>
         </Flex>
-    {/each}
 
-    <Flex class="mb-8 w-full gap-4">
-        <Input bind:value={key} label={false} placeholder="Key" class="uppercase" />
-        <Input bind:value onchange={addEnv} label={false} placeholder="Value" />
-        <div class="w-16"></div>
-    </Flex>
+        {#each env, i (i)}
+            <Flex class="mb-4 w-full gap-4">
+                <Input
+                    onchange={update}
+                    label={false}
+                    placeholder="Key"
+                    bind:value={env[i][0]}
+                    class="uppercase"
+                />
+
+                <Input onchange={update} label={false} placeholder="Value" bind:value={env[i][1]} />
+
+                <button
+                    class="text-dark hover:text-red ml-4 transition duration-300 hover:cursor-pointer"
+                    onclick={() => remove(env[i][0])}
+                >
+                    <Svg name="Delete" class="h-4 w-4" />
+                </button>
+            </Flex>
+        {/each}
+
+        <Flex class="mb-8 w-full gap-4">
+            <Input bind:value={key} label={false} placeholder="Key" class="uppercase" />
+            <Input bind:value onchange={addEnv} label={false} placeholder="Value" />
+            <div class="w-16"></div>
+        </Flex>
+    {:else}
+        <!-- HTTP Transport Fields -->
+        <h2 class="text-medium mb-4 ml-4 text-xl">Server URL</h2>
+
+        <Input
+            bind:value={transportConfig.url}
+            label={false}
+            name="url"
+            class="w-full"
+            onchange={update}
+            placeholder="https://example.com/mcp"
+        />
+        <div class="text-dark mt-2 ml-4 text-xs">
+            Enter the full URL where your MCP server is hosted. Make sure the server is running and accessible.
+        </div>
+
+        <h2 class="text-medium mt-8 mb-4 ml-4 text-xl">Authentication (Optional)</h2>
+
+        <Flex class="mb-4 w-full gap-4">
+            <select
+                bind:value={transportConfig.authentication.type}
+                onchange={update}
+                class="border-light w-full rounded-md border p-2 px-4 outline-none"
+            >
+                <option value="none">No Authentication</option>
+                <option value="bearer">Bearer Token</option>
+                <option value="basic">Basic Auth</option>
+            </select>
+        </Flex>
+
+        {#if transportConfig.authentication.type === 'bearer'}
+            <Input
+                bind:value={transportConfig.authentication.token}
+                label={false}
+                name="token"
+                class="mb-4 w-full"
+                onchange={update}
+                placeholder="Bearer token"
+            />
+        {:else if transportConfig.authentication.type === 'basic'}
+            <Flex class="mb-4 w-full gap-4">
+                <Input
+                    bind:value={transportConfig.authentication.username}
+                    label={false}
+                    name="username"
+                    onchange={update}
+                    placeholder="Username"
+                />
+                <Input
+                    bind:value={transportConfig.authentication.password}
+                    label={false}
+                    name="password"
+                    type="password"
+                    onchange={update}
+                    placeholder="Password"
+                />
+            </Flex>
+        {/if}
+
+        <h2 class="text-medium mt-8 mb-4 ml-4 text-xl">Settings (Optional)</h2>
+
+        <Flex class="mb-4 w-full gap-4">
+            <Input
+                bind:value={transportConfig.timeout}
+                label="Timeout (ms)"
+                name="timeout"
+                type="number"
+                onchange={update}
+                placeholder="30000"
+            />
+            <Input
+                bind:value={transportConfig.retries}
+                label="Retries"
+                name="retries"
+                type="number"
+                onchange={update}
+                placeholder="3"
+            />
+        </Flex>
+    {/if}
 
     {#if !server?.id}
         <Flex class="w-full">

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -25,7 +25,7 @@
     });
 </script>
 
-<div class="fixed top-0 left-0 z-40 h-screen w-screen bg-dark/80"></div>
+<div class="bg-dark/80 fixed top-0 left-0 z-40 h-screen w-screen"></div>
 
 <div
     bind:this={ref}

--- a/src/components/Spinner.svelte
+++ b/src/components/Spinner.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-    import { twMerge } from 'tailwind-merge';
-
     const { class: cls = 'w-[24px] h-[24px]' } = $props();
 </script>
 
-<div class={twMerge('spinner', cls?.toString())}></div>
+<div class={`spinner ${cls?.toString()}`}></div>
 
 <style>
     .spinner {

--- a/src/lib/deeplinks.ts
+++ b/src/lib/deeplinks.ts
@@ -6,6 +6,18 @@ export interface VSCodeMcpInstallConfig {
     type: string;
     command: string;
     args: string[];
+    // HTTP transport specific fields
+    url?: string;
+    transport?: 'stdio' | 'http';
+    authentication?: {
+        type: 'none' | 'bearer' | 'basic';
+        token?: string;
+        username?: string;
+        password?: string;
+    };
+    headers?: Record<string, string>;
+    timeout?: number;
+    retries?: number;
 }
 
 export enum DeepLinks {
@@ -14,6 +26,91 @@ export enum DeepLinks {
 
 export function setupDeeplinks() {
     listen<string>(DeepLinks.InstallMcpServer, async event => {
-        goto(`/mcp-servers/install?config=${event.payload}`);
+        const config = parseDeepLinkConfig(event.payload);
+        const configParam = encodeURIComponent(JSON.stringify(config));
+        goto(`/mcp-servers/install?config=${configParam}`);
     });
+}
+
+// Parse deep link query parameters into VSCodeMcpInstallConfig
+function parseDeepLinkConfig(query: string): VSCodeMcpInstallConfig {
+    const params = new URLSearchParams(query);
+
+    const name = params.get('name');
+    const transport = (params.get('transport') as 'stdio' | 'http') || 'stdio';
+    const url = params.get('url');
+    const command = params.get('command');
+    const args = params.get('args');
+
+    if (!name) {
+        throw new Error('Missing required parameter: name');
+    }
+
+    if (transport === 'http') {
+        if (!url) {
+            throw new Error('HTTP transport requires url parameter');
+        }
+
+        const config: VSCodeMcpInstallConfig = {
+            name,
+            type: 'http',
+            transport: 'http',
+            url,
+            command: '', // Not used for HTTP transport
+            args: [], // Not used for HTTP transport
+            authentication: {
+                type: 'none',
+            },
+        };
+
+        // Parse authentication if provided
+        const authType = params.get('auth_type') as 'none' | 'bearer' | 'basic';
+        if (authType) {
+            config.authentication = {
+                type: authType,
+                token: params.get('auth_token') || undefined,
+                username: params.get('auth_username') || undefined,
+                password: params.get('auth_password') || undefined,
+            };
+        }
+
+        // Parse headers if provided
+        const headers: Record<string, string> = {};
+        for (const [key, value] of params.entries()) {
+            if (key.startsWith('header_')) {
+                const headerName = key.substring(7); // Remove 'header_' prefix
+                headers[headerName] = value;
+            }
+        }
+        if (Object.keys(headers).length > 0) {
+            config.headers = headers;
+        }
+
+        // Parse optional timeout and retries
+        const timeout = params.get('timeout');
+        if (timeout) {
+            config.timeout = parseInt(timeout, 10);
+        }
+
+        const retries = params.get('retries');
+        if (retries) {
+            config.retries = parseInt(retries, 10);
+        }
+
+        return config;
+    } else {
+        // Default to stdio transport for backward compatibility
+        if (!command) {
+            throw new Error('Stdio transport requires command parameter');
+        }
+
+        return {
+            name,
+            type: 'stdio',
+            transport: 'stdio',
+            command,
+            args: args ? JSON.parse(args) : [],
+            url: undefined,
+        };
+    }
 }

--- a/src/lib/models/index.ts
+++ b/src/lib/models/index.ts
@@ -15,7 +15,7 @@ export { default as BareModel } from '$lib/models/bare.svelte';
 export { default as Base, type ToSqlRow } from '$lib/models/base.svelte';
 export { default as Config } from '$lib/models/config.svelte';
 export { default as Engine } from '$lib/models/engine.svelte';
-export { default as McpServer } from '$lib/models/mcp-server.svelte';
+export { default as McpServer, type TransportConfig } from '$lib/models/mcp-server.svelte';
 export { default as Message } from '$lib/models/message.svelte';
 export { default as Model } from '$lib/models/model.svelte';
 export { default as Session } from '$lib/models/session.svelte';

--- a/src/lib/models/mcp-server.svelte.ts
+++ b/src/lib/models/mcp-server.svelte.ts
@@ -10,6 +10,8 @@ interface Row {
     metadata: string;
     args: string;
     env: string;
+    transport_type: string;
+    transport_config: string;
 }
 
 interface Metadata {
@@ -23,6 +25,19 @@ interface Metadata {
     };
 }
 
+export interface TransportConfig {
+    url?: string;
+    authentication: {
+        type: 'none' | 'bearer' | 'basic';
+        token?: string;
+        username?: string;
+        password?: string;
+    };
+    headers?: Record<string, string>;
+    timeout?: number;
+    retries?: number;
+}
+
 export default class McpServer extends Base<Row>('mcp_servers') {
     id?: number = $state();
     name: string = $state('Installing...');
@@ -30,6 +45,12 @@ export default class McpServer extends Base<Row>('mcp_servers') {
     metadata?: Metadata = $state({} as Metadata);
     args: string[] = $state([]);
     env: Record<string, string> = $state({});
+    transportType: string = $state('stdio');
+    transportConfig: TransportConfig = $state({
+        authentication: {
+            type: 'none',
+        },
+    });
 
     get defaults() {
         return {
@@ -47,6 +68,12 @@ export default class McpServer extends Base<Row>('mcp_servers') {
             },
             args: [],
             env: {},
+            transportType: 'stdio',
+            transportConfig: {
+                authentication: {
+                    type: 'none',
+                },
+            },
         };
     }
 
@@ -65,11 +92,31 @@ export default class McpServer extends Base<Row>('mcp_servers') {
     }
 
     async start(session: Session) {
+        // Validate transport configuration before starting
+        if (this.transportType === 'http') {
+            if (!this.transportConfig?.url) {
+                throw new Error(`HTTP transport requires a URL for server ${this.name}`);
+            }
+            
+            // Validate URL format
+            try {
+                new URL(this.transportConfig.url);
+            } catch (e) {
+                throw new Error(`Invalid URL format for HTTP transport: ${this.transportConfig.url}`);
+            }
+        } else if (this.transportType === 'stdio') {
+            if (!this.command) {
+                throw new Error(`Stdio transport requires a command for server ${this.name}`);
+            }
+        }
+
         await invoke('start_mcp_server', {
             sessionId: session.id,
             command: this.command,
             args: this.args,
             env: this.env,
+            transport_type: this.transportType,
+            transport_config: this.transportConfig,
         });
     }
 
@@ -80,12 +127,50 @@ export default class McpServer extends Base<Row>('mcp_servers') {
         });
     }
 
+    get displayInfo(): string {
+        if (this.transportType === 'http') {
+            return `HTTP: ${this.transportConfig?.url || 'No URL configured'}`;
+        } else {
+            return `Stdio: ${this.command} ${this.args.join(' ')}`;
+        }
+    }
+
+    get isConfigured(): boolean {
+        if (this.transportType === 'http') {
+            return !!(this.transportConfig?.url);
+        } else {
+            return !!(this.command);
+        }
+    }
+
     async beforeCreate(row: Row): Promise<ToSqlRow<Row>> {
+        // Validate transport configuration before creation
+        const transportConfig = JSON.parse(row.transport_config);
+        
+        if (row.transport_type === 'http') {
+            if (!transportConfig?.url) {
+                throw new Error('HTTP transport requires a URL');
+            }
+            
+            // Validate URL format
+            try {
+                new URL(transportConfig.url);
+            } catch (e) {
+                throw new Error(`Invalid URL format: ${transportConfig.url}`);
+            }
+        } else if (row.transport_type === 'stdio') {
+            if (!row.command) {
+                throw new Error('Stdio transport requires a command');
+            }
+        }
+
         const metadata: Metadata = JSON.parse(
             await invoke('get_metadata', {
                 command: row.command,
                 args: JSON.parse(row.args),
                 env: JSON.parse(row.env),
+                transport_type: row.transport_type,
+                transport_config: JSON.parse(row.transport_config),
             })
         );
 
@@ -98,6 +183,12 @@ export default class McpServer extends Base<Row>('mcp_servers') {
     }
 
     static async fromSql(row: Row): Promise<McpServer> {
+        const config = JSON.parse(row.transport_config);
+        // Ensure authentication is always present
+        if (!config.authentication) {
+            config.authentication = { type: 'none' };
+        }
+
         return McpServer.new({
             id: row.id,
             name: row.name,
@@ -105,6 +196,8 @@ export default class McpServer extends Base<Row>('mcp_servers') {
             metadata: JSON.parse(row.metadata),
             args: JSON.parse(row.args),
             env: JSON.parse(row.env),
+            transportType: row.transport_type,
+            transportConfig: config,
         });
     }
 
@@ -115,6 +208,8 @@ export default class McpServer extends Base<Row>('mcp_servers') {
             metadata: JSON.stringify(this.metadata),
             args: JSON.stringify(this.args),
             env: JSON.stringify(this.env),
+            transport_type: this.transportType,
+            transport_config: JSON.stringify(this.transportConfig),
         };
     }
 

--- a/src/routes/chat/[session_id]/+page.svelte
+++ b/src/routes/chat/[session_id]/+page.svelte
@@ -177,16 +177,27 @@
 
                 <div class="mt-4">
                     {#each mcpServers as server (server.id)}
-                        <Flex class="text-light z-0 mb-4 ml-2">
+                        <Flex class="text-light z-0 mb-4 ml-2 flex-col items-start">
                             <Toggle
                                 label={server.name}
-                                value={session.hasMcpServer(server.name) && model?.supportsTools
+                                value={session.hasMcpServer(server.name) && model?.supportsTools && server.isConfigured
                                     ? 'on'
                                     : 'off'}
-                                disabled={!model?.supportsTools}
+                                disabled={!model?.supportsTools || !server.isConfigured}
                                 onEnable={() => startMcpServer(server)}
                                 onDisable={() => stopMcpServer(server)}
                             />
+                            <div class="text-dark ml-8 mt-1 text-xs">
+                                {server.transportType.toUpperCase()}
+                                {#if server.transportType === 'http' && server.transportConfig?.url}
+                                    - {server.transportConfig.url}
+                                {:else if server.transportType === 'stdio' && server.command}
+                                    - {server.command}
+                                {/if}
+                                {#if !server.isConfigured}
+                                    <span class="text-red ml-2">(Not configured)</span>
+                                {/if}
+                            </div>
                         </Flex>
                     {/each}
                 </div>

--- a/src/routes/mcp-servers/install/+page.svelte
+++ b/src/routes/mcp-servers/install/+page.svelte
@@ -13,8 +13,32 @@
     const payload = page.url.searchParams.get('config') as string;
     const config: VSCodeMcpInstallConfig = JSON.parse(decodeURIComponent(payload));
 
+    // Determine transport type for compatibility
+    const transport = config.transport || (config.type === 'http' ? 'http' : 'stdio');
+
     async function install() {
-        const server = await McpServer.create(config);
+        // Create the server configuration based on transport type
+        const serverConfig = {
+            name: config.name,
+            command: config.command || '',
+            args: config.args || [],
+            env: {},
+            transportType: transport,
+            transportConfig:
+                transport === 'http'
+                    ? {
+                          url: config.url,
+                          authentication: config.authentication || { type: 'none' as const },
+                          headers: config.headers || {},
+                          timeout: config.timeout || 30,
+                          retries: config.retries || 3,
+                      }
+                    : {
+                          authentication: { type: 'none' as const },
+                      },
+        };
+
+        const server = await McpServer.create(serverConfig);
         goto(`/mcp-servers/${server.name}`);
     }
 
@@ -25,11 +49,13 @@
 
 <Layout>
     <Modal close={cancel}>
-        {#if config.type !== 'stdio'}
+        {#if transport !== 'stdio' && transport !== 'http'}
             <Flex class="text-red w-full">
                 <Svg name="Warning" class="mr-8 h-6 w-6" />
                 <p>
                     Tome only supports <code>stdio</code>
+                    and
+                    <code>http</code>
                     MCP servers
                 </p>
             </Flex>
@@ -37,15 +63,59 @@
             <Flex class="w-full flex-col items-start">
                 <h2 class="ml-2">Install {config.name}?</h2>
 
-                <Flex class="border-light mt-4 w-full flex-col items-start rounded-md border">
-                    <h3 class="text-medium p-2 pl-4 text-sm">Command</h3>
-                    <Flex class="border-t-light w-full overflow-x-scroll border-t p-2 pl-4">
-                        <code class="whitespace-nowrap">
-                            {config.command}
-                            {config.args.join(' ')}
-                        </code>
+                {#if transport === 'http'}
+                    <Flex class="border-light mt-4 w-full flex-col items-start rounded-md border">
+                        <h3 class="text-medium p-2 pl-4 text-sm">HTTP Endpoint</h3>
+                        <Flex class="border-t-light w-full overflow-x-scroll border-t p-2 pl-4">
+                            <code class="whitespace-nowrap">
+                                {config.url}
+                            </code>
+                        </Flex>
                     </Flex>
-                </Flex>
+
+                    {#if config.authentication && config.authentication.type !== 'none'}
+                        <Flex
+                            class="border-light mt-4 w-full flex-col items-start rounded-md border"
+                        >
+                            <h3 class="text-medium p-2 pl-4 text-sm">Authentication</h3>
+                            <Flex class="border-t-light w-full overflow-x-scroll border-t p-2 pl-4">
+                                <code class="whitespace-nowrap">
+                                    {config.authentication.type}
+                                    {#if config.authentication.type === 'bearer' && config.authentication.token}
+                                        (Token: {config.authentication.token.substring(0, 10)}...)
+                                    {:else if config.authentication.type === 'basic' && config.authentication.username}
+                                        (Username: {config.authentication.username})
+                                    {/if}
+                                </code>
+                            </Flex>
+                        </Flex>
+                    {/if}
+
+                    {#if config.headers && Object.keys(config.headers).length > 0}
+                        <Flex
+                            class="border-light mt-4 w-full flex-col items-start rounded-md border"
+                        >
+                            <h3 class="text-medium p-2 pl-4 text-sm">Headers</h3>
+                            <Flex class="border-t-light w-full overflow-x-scroll border-t p-2 pl-4">
+                                <code class="whitespace-nowrap">
+                                    {Object.entries(config.headers)
+                                        .map(([k, v]) => `${k}: ${v}`)
+                                        .join(', ')}
+                                </code>
+                            </Flex>
+                        </Flex>
+                    {/if}
+                {:else}
+                    <Flex class="border-light mt-4 w-full flex-col items-start rounded-md border">
+                        <h3 class="text-medium p-2 pl-4 text-sm">Command</h3>
+                        <Flex class="border-t-light w-full overflow-x-scroll border-t p-2 pl-4">
+                            <code class="whitespace-nowrap">
+                                {config.command}
+                                {config.args?.join(' ') || ''}
+                            </code>
+                        </Flex>
+                    </Flex>
+                {/if}
 
                 <Flex class="mt-8 self-end">
                     <Button onclick={cancel} class="text-medium border-0">Cancel</Button>


### PR DESCRIPTION
Alright, so this is me biting off more than I can chew. I'm still testing out fixing #89 but wanted to get this up for feedback.

  Big changes here are as follows:

  1. Adding transport_type and config - Was on the fence of just adding them into metadata but decided to make them proper columns. Now MCP servers can be either stdio (the old way) or
  HTTP.
  2. http.rs - I "think" this will work to hook into the streamable MCP servers (still testing). It's got session management, SSE streaming, the whole nine yards. Follows the MCP
  protocol but over HTTP instead of pipes.
  3. UI updates - Had to update the MCP server component to handle both transport types. You can now configure HTTP servers with URLs, auth, headers, etc.
  4. Database migration - Added the new columns with defaults so existing servers don't break.
  5. Deep link additions - Enhanced the tome:// URL handling to support HTTP servers too.

  🚧 Still testing - The HTTP stuff compiles and looks right but I haven't actually tested it with a real streamable MCP server yet. The stdio path should still work fine though.