### PR TITLE
Scrollbars are dumb

### DIFF
--- a/src/components/List.svelte
+++ b/src/components/List.svelte
@@ -42,7 +42,7 @@
     }
 </script>
 
-<Flex class={twMerge('w-full flex-col items-start overflow-y-scroll', cls?.toString())}>
+<Flex class={twMerge('w-full flex-col items-start overflow-y-auto', cls?.toString())}>
     {#if title}
         <p class={twMerge('text-medium text-sm', titleClass?.toString())}>
             {title}
@@ -65,7 +65,7 @@
 
     {#if items.length > 0}
         {#each filter() as item, i (i)}
-            <div class={twMerge('w-full', css)}>
+            <div class={twMerge('w-full', css?.toString())}>
                 {@render itemView(item)}
             </div>
         {/each}


### PR DESCRIPTION
The `overflow: scroll` was forcing the rendering of the scrollbar gutter. Whether that gutter affects the rest of the elements or not is system-set – not something controllable via CSS.

Because we had the `overflow: scroll` there was almost always extra padding in `Lists` where the scrollbar _would_ go, but most of the time there wasn't one because the list wasn't long enough.

This removes that space unless the List truly needs to scroll.

---

<p align="center">
<img width="214" alt="image" src="https://github.com/user-attachments/assets/ef12b892-7b77-4e0d-a25a-16941ed4a474" />
</p>
<p align="center">↓</p>
<p align="center">
<img width="239" alt="image" src="https://github.com/user-attachments/assets/8b2fc707-107e-4d7e-a5fb-7768d8e9384d" />
</p>
