### PR TITLE
Remove svelte autofocus warning

### DIFF
--- a/src/routes/mcp-servers/+layout.svelte
+++ b/src/routes/mcp-servers/+layout.svelte
@@ -90,6 +90,7 @@
                         handleRename();
                     }}
                 >
+                    <!-- svelte-ignore a11y_autofocus -->
                     <input
                         type="text"
                         bind:value={newName}


### PR DESCRIPTION
I'm not entirely sure Tome works with screenreaders at all, yet. So remove this warning for the time being.