### PR TITLE
Prevent dash replacement

### DIFF
--- a/src/components/Input.svelte
+++ b/src/components/Input.svelte
@@ -42,6 +42,7 @@
         class:border-red={!valid}
         onkeyup={() => (valid = validate(value))}
         onblur={() => (valid = validate(value))}
+        spellcheck="false"
         autocorrect="off"
         autocomplete="off"
         {name}


### PR DESCRIPTION
Apparently, having `spellcheck=true` enables the replacement of two dashes with an emdash.

This was screwing up CLI args to MCP servers (and probably other things).