### PR TITLE
Colorscheme on startup

### DIFF
--- a/src/components/Settings/CustomPrompt.svelte
+++ b/src/components/Settings/CustomPrompt.svelte
@@ -3,7 +3,7 @@
 
     import Box from '$components/Box.svelte';
     import Textarea from '$components/Textarea.svelte';
-    import Setting, { CUSTOM_SYSTEM_PROMPT } from '$lib/models/setting.svelte';
+    import Setting from '$lib/models/setting.svelte';
 
     interface Props {
         saving?: boolean;
@@ -38,20 +38,7 @@
 
         try {
             isSaving = true;
-            const existingSetting = Setting.findBy({ key: CUSTOM_SYSTEM_PROMPT });
-
-            if (existingSetting) {
-                existingSetting.value = customPrompt;
-                await existingSetting.save();
-            } else {
-                await Setting.create({
-                    display: 'Custom System Prompt',
-                    key: CUSTOM_SYSTEM_PROMPT,
-                    value: customPrompt,
-                    type: 'string',
-                });
-            }
-
+            Setting.CustomSystemPrompt = customPrompt;
             saving = true;
             setTimeout(() => (saving = false), 2000);
         } catch (error) {

--- a/src/lib/colorscheme.ts
+++ b/src/lib/colorscheme.ts
@@ -1,0 +1,13 @@
+export type ColorScheme = 'system' | 'light' | 'dark';
+
+export function apply(scheme: ColorScheme = 'system') {
+    if (scheme == 'system') {
+        scheme = systemScheme();
+    }
+
+    document.documentElement.setAttribute('data-theme', scheme);
+}
+
+function systemScheme() {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}

--- a/src/lib/models/setting.svelte.ts
+++ b/src/lib/models/setting.svelte.ts
@@ -1,26 +1,16 @@
+import * as color from '$lib/colorscheme';
 import { Engine } from '$lib/models';
 import Base, { type ToSqlRow } from '$lib/models/base.svelte';
 
-// OpenAI API Key
-const OPENAI_API_KEY = 'openai-api-key';
-
-// Gemini API Key
-const GEMINI_API_KEY = 'gemini-api-key';
-
-// Ollama URL
-export const OLLAMA_URL_CONFIG_KEY = 'ollama-url';
-
 // Custom System Prompt
 export const CUSTOM_SYSTEM_PROMPT = 'custom-system-prompt';
-const COLOR_SCHEME_KEY = 'color-scheme';
 
-export interface ISetting {
-    id?: number;
-    display: string;
-    key: string;
-    value: unknown;
-    type: string;
-}
+export type SettingKey =
+    | 'openai-api-key'
+    | 'gemini-api-key'
+    | 'ollama-url'
+    | 'custom-system-prompt'
+    | 'color-scheme';
 
 interface Row {
     id: number;
@@ -37,37 +27,28 @@ export default class Setting extends Base<Row>('settings') {
     value: unknown = $state('');
     type: string = $state('');
 
-    static get OllamaUrl(): string | undefined {
-        return this.findBy({ key: OLLAMA_URL_CONFIG_KEY })?.value as string | undefined;
-    }
+    @getset('openai-api-key')
+    static OpenAIKey: string;
 
-    static get OpenAIKey(): string | undefined {
-        return this.findBy({ key: OPENAI_API_KEY })?.value as string | undefined;
-    }
+    @getset('gemini-api-key')
+    static GeminiApiKey: string;
 
-    static get GeminiApiKey(): string | undefined {
-        return this.findBy({ key: GEMINI_API_KEY })?.value as string | undefined;
-    }
+    @getset('ollama-url')
+    static OllamaUrl: string;
 
-    static get CustomSystemPrompt(): string | undefined {
-        return this.findBy({ key: CUSTOM_SYSTEM_PROMPT })?.value as string | undefined;
-    }
+    @getset('custom-system-prompt')
+    static CustomSystemPrompt: string;
 
-    static get ColorScheme(): string | undefined {
-        return this.findBy({ key: COLOR_SCHEME_KEY })?.value as string | undefined;
-    }
-
-    static set ColorScheme(value: string | undefined) {
-        const setting = this.findBy({ key: COLOR_SCHEME_KEY });
-        if (setting && value) {
-            setting.value = value;
-            setting.save();
-        }
-    }
+    @getset('color-scheme')
+    static ColorScheme: color.ColorScheme;
 
     protected static async afterUpdate() {
         // Resync models in case a Provider key/url was updated.
         await Engine.sync();
+    }
+
+    protected async afterSave() {
+        color.apply(Setting.ColorScheme);
     }
 
     protected static async fromSql(row: Row): Promise<Setting> {
@@ -88,4 +69,23 @@ export default class Setting extends Base<Row>('settings') {
             type: this.type,
         };
     }
+}
+
+function getset(key: SettingKey) {
+    return function (target: object, property: string) {
+        function get() {
+            return Setting.findBy({ key })?.value;
+        }
+
+        async function set(value: unknown) {
+            const setting = Setting.findBy({ key }) || Setting.new({ key });
+            setting.value = value;
+            await setting.save();
+        }
+
+        Object.defineProperty(target, property, {
+            get,
+            set,
+        });
+    };
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
     import { goto, onNavigate } from '$app/navigation';
 
     import closables from '$lib/closables';
+    import * as colorscheme from '$lib/colorscheme';
     import { Setting } from '$lib/models';
     import { resync } from '$lib/models';
 
@@ -40,7 +41,7 @@
     }
 
     onMount(() => {
-        document.documentElement.setAttribute('data-theme', Setting.ColorScheme as string);
+        colorscheme.apply(Setting.ColorScheme);
     });
 
     onNavigate(navigation => {

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -7,6 +7,7 @@
     import EngineView from '$components/Settings/Engine.svelte';
     import Svg from '$components/Svg.svelte';
     import Titlebar from '$components/Titlebar.svelte';
+    import * as color from '$lib/colorscheme';
     import Engine from '$lib/models/engine.svelte';
     import Setting from '$lib/models/setting.svelte';
 
@@ -14,29 +15,14 @@
 
     let adding = $state(false);
     let saving = $state(false);
+    let scheme: color.ColorScheme = $state(Setting.ColorScheme ?? 'system');
 
     // Color scheme state
-    let colorScheme = $state(Setting.ColorScheme ?? 'system');
 
-    function onColorSchemeChange(e: Event) {
-        colorScheme = (e.target as HTMLSelectElement).value;
-        Setting.ColorScheme = colorScheme;
-        applyColorScheme(colorScheme);
+    function onColorSchemeChange() {
+        Setting.ColorScheme = scheme;
+        color.apply(scheme);
     }
-
-    function applyColorScheme(scheme: string) {
-        if (scheme === 'system') {
-            const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-            document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
-        } else {
-            document.documentElement.setAttribute('data-theme', scheme);
-        }
-    }
-
-    // Apply on load and whenever colorScheme changes
-    $effect(() => {
-        applyColorScheme(colorScheme);
-    });
 
     async function ondelete(engine: Engine) {
         await engine.delete();
@@ -70,7 +56,7 @@
                 <Flex class="w-full flex-col items-start gap-2">
                     <select
                         class="border-light bg-medium text-light mt-2 rounded-md border p-2"
-                        bind:value={colorScheme}
+                        bind:value={scheme}
                         onchange={onColorSchemeChange}
                     >
                         <option value="system">System</option>


### PR DESCRIPTION
Duplicates the `@getset` decorator from `Config` to `Setting` (need to consolidate this in the future).

Now `Setting` works the same way, in that you can get and set Settings via the static properties. For example,

```ts
Setting.ColorScheme = 'dark'; // Saves this to the db
```

Also ensures the colorscheme is set on startup (there is a short period where it may be wrong, while the front-end loads).