### PR TITLE
Ensure MCP and Task main content areas are scrollable

### DIFF
--- a/src/components/Scrollable.svelte
+++ b/src/components/Scrollable.svelte
@@ -11,7 +11,7 @@
     let { children, ref = $bindable(), class: cls = '' }: Props = $props();
 </script>
 
-<Flex bind:ref class={twMerge('h-full w-full items-start overflow-y-scroll', cls?.toString())}>
+<Flex bind:ref class={twMerge('h-content w-full items-start overflow-y-scroll', cls?.toString())}>
     <div class="w-full">
         {@render children?.()}
     </div>

--- a/src/routes/mcp-servers/+layout.svelte
+++ b/src/routes/mcp-servers/+layout.svelte
@@ -8,6 +8,7 @@
     import List from '$components/List.svelte';
     import type { MenuItem } from '$components/Menu.svelte';
     import Menu from '$components/Menu.svelte';
+    import Scrollable from '$components/Scrollable.svelte';
     import Svg from '$components/Svg.svelte';
     import Titlebar from '$components/Titlebar.svelte';
     import { McpServer } from '$lib/models';
@@ -139,7 +140,9 @@
         </Flex>
 
         <Flex class="h-full w-[calc(100%-300px)] items-start p-8">
-            {@render children?.()}
+            <Scrollable>
+                {@render children?.()}
+            </Scrollable>
         </Flex>
     </Flex>
 </Layout>

--- a/src/routes/tasks/+layout.svelte
+++ b/src/routes/tasks/+layout.svelte
@@ -8,6 +8,7 @@
     import List from '$components/List.svelte';
     import type { MenuItem } from '$components/Menu.svelte';
     import Menu from '$components/Menu.svelte';
+    import Scrollable from '$components/Scrollable.svelte';
     import Titlebar from '$components/Titlebar.svelte';
     import Task from '$lib/models/task.svelte';
     import { execute } from '$lib/tasks';
@@ -88,7 +89,9 @@
         </Flex>
 
         <Flex class="h-full w-[calc(100%-300px)] items-start">
-            {@render children?.()}
+            <Scrollable>
+                {@render children?.()}
+            </Scrollable>
         </Flex>
     </Flex>
 </Layout>


### PR DESCRIPTION
Wraps all main panes in a `Scrollable` to ensure they don't get cut off and become inaccessible.