### PR TITLE
Bump 0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-- Added support for ![iMCP](https://github.com/mattt/iMCP) (macos only)
+- Added support for [iMCP](https://github.com/mattt/iMCP) (macos only)
 
 ### Misc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.9.3 - 2025-07-28
+
+### New Features
+
+- Added support for ![iMCP](https://github.com/mattt/iMCP) (macos only)
+
+### Misc
+
+- Added a View Logs button to the settings page
+
 ## 0.9.2 - 2025-07-07
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "tome",
     "private": true,
-    "version": "0.9.2",
+    "version": "0.9.3",
     "type": "module",
     "scripts": {
         "dev": "vite dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Tome"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Tome"
-version = "0.9.2"
+version = "0.9.3"
 description = "The easiest way to work with local models and MCP servers."
 authors = ["Runebook"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -58,7 +58,7 @@
     },
     "productName": "Tome",
     "mainBinaryName": "tome",
-    "version": "0.9.2",
+    "version": "0.9.3",
     "identifier": "co.runebook",
     "plugins": {
         "sql": {


### PR DESCRIPTION
## 0.9.3 - 2025-07-28

### New Features

- Added support for [iMCP](https://github.com/mattt/iMCP) (macos only)

### Misc

- Added a View Logs button to the settings page