### PR TITLE
Send MCP server stderr to Tome logs

### DIFF
--- a/src-tauri/src/mcp/process.rs
+++ b/src-tauri/src/mcp/process.rs
@@ -32,7 +32,8 @@ impl McpProcess {
         cmd.kill_on_drop(true)
             .envs(env)
             .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped());
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::inherit());
 
         #[cfg(windows)]
         {

--- a/src/components/Mcp/Page.svelte
+++ b/src/components/Mcp/Page.svelte
@@ -17,7 +17,8 @@
         try {
             const s = await server.save();
             await onsave?.(s);
-        } catch {
+        } catch (err) {
+            console.error(err);
             error = 'error starting the server';
         }
     }


### PR DESCRIPTION
Proxies all `stderr` output from MCP servers to the Tome logs.