### PR TITLE
feat: add uv command support and fix Gemini schema validation

### DIFF
--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -27,6 +27,13 @@ pub fn get_os_specific_command(command: &str, app: &AppHandle) -> Result<Command
                 "python"
             }
         }
+        "uv" => {
+            if cfg!(windows) {
+                "uv.exe"
+            } else {
+                "uv"
+            }
+        }
         "uvx" => {
             if cfg!(windows) {
                 "uvx.exe"
@@ -216,7 +223,7 @@ pub async fn peer_info(
     app: AppHandle,
 ) -> Result<String> {
     match tokio::time::timeout(
-        Duration::from_secs(5),
+        Duration::from_secs(30),
         McpServer::start(command, args, env, app),
     )
     .await

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,6 +44,7 @@
         },
         "resources": {
             "python": "python",
+            "uv": "uv",
             "uvx": "uvx",
             "node": "node",
             "npx": "npx",

--- a/src-tauri/uv
+++ b/src-tauri/uv
@@ -1,0 +1,70 @@
+#!/bin/bash
+# This product includes software developed at Square, Inc.
+# 
+# The Initial Developer of some parts of the framework, which are copied 
+# from, derived from, or inspired by Hermit, is Square, Inc. (https://squareup.com).
+# Copyright 2021 Square, Inc. All Rights Reserved.
+# 
+# The Initial Developer of Hermit is Square, Inc. (http://www.squareup.com).
+# Copyright 2021 Square, Inc. All Rights Reserved.
+
+set -euo pipefail
+LOGFILE="$HOME/Library/Logs/co.runebook/Tome.log"
+echo >> $LOGFILE
+
+log() {
+    local LINE="$1"
+    local DATE="$(date +'%Y-%m-%d')"
+    local TIME="$(date +'%H:%M:%S')"
+    echo "[$DATE][$TIME][hermit][DEBUG] $LINE" >> $LOGFILE
+}
+trap 'log "ERROR: Exiting w/ status: $?."' ERR
+
+log "Starting..."
+
+log "mkdir -p ~/.config/runebook/hermit/bin ?"
+mkdir -p ~/.config/runebook/hermit/bin
+
+log "cd ~/.config/runebook/hermit"
+cd ~/.config/runebook/hermit
+
+if [ ! -f ~/.config/runebook/hermit/bin/hermit ]; then
+    log "Downloading hermit..."
+    curl -fsSL "https://github.com/cashapp/hermit/releases/download/stable/hermit-$(uname -s \
+        | tr '[:upper:]' '[:lower:]')-$(uname -m \
+        | sed 's/x86_64/amd64/' \
+        | sed 's/aarch64/arm64/').gz" \
+        | gzip -dc > ~/.config/runebook/hermit/bin/hermit
+    log "Downloaded hermit..."
+
+    log "chmod +x ~/.config/runebook/hermit/bin/hermit"
+    chmod +x ~/.config/runebook/hermit/bin/hermit
+else
+    log "Found existing hermit..."
+fi
+
+log "mkdir -p ~/.config/runebook/hermit/cache"
+mkdir -p ~/.config/runebook/hermit/cache
+
+log "export HERMIT_STATE_DIR=~/.config/runebook/hermit/cache"
+export HERMIT_STATE_DIR=~/.config/runebook/hermit/cache
+
+log "export PATH=~/.config/runebook/hermit/bin:$PATH"
+export PATH=~/.config/runebook/hermit/bin:$PATH
+
+log "hermit init"
+hermit init >> "$LOGFILE"
+
+log "chmod +x hermit"
+chmod +x ~/.config/runebook/hermit/bin/hermit
+
+log "hermit install python@3.12"
+hermit install python3@3.12 >> "$LOGFILE"
+
+log "hermit install uv"
+hermit install uv >> "$LOGFILE"
+
+log "uv $*"
+uv "$@" || log "Error running uv $*"
+
+log "End."

--- a/src/lib/engines/gemini/tool.ts
+++ b/src/lib/engines/gemini/tool.ts
@@ -40,7 +40,7 @@ function fromOne(tool: Tool): FunctionDeclaration {
         name,
         {
             ...prop,
-            type: toGeminiType(prop.type),
+            ...(prop.type && !prop.anyOf ? { type: toGeminiType(prop.type) } : {}),
         },
     ]);
 


### PR DESCRIPTION
## Summary
This PR adds support for the `uv` command in MCP server spawning and fixes schema validation issues with Gemini AI models.

## Changes Made

### 1. Added `uv` Command Support
- Modified `src-tauri/src/mcp.rs` to recognize `uv` as a valid MCP command
- Created `src-tauri/uv` wrapper script with Hermit integration (similar to existing `uvx` wrapper)
- Updated `src-tauri/tauri.conf.json` to bundle the `uv` binary

### 2. Increased MCP Initialization Timeout
- Changed timeout from 5 seconds to 30 seconds in `peer_info` function
- Allows MCP servers with longer initialization times to connect successfully

### 3. Fixed Gemini Schema Validation
- Modified `src/lib/engines/gemini/tool.ts` to handle `anyOf` in JSON schemas
- Prevents adding `type` field when `anyOf` is already present
- Resolves "type and anyOf cannot be both populated" error

## Problem Solved

MCP servers that use:
- The `uv` command (e.g., `uv --directory /path/to/project run server`)
- Longer initialization times (>5 seconds)
- Complex parameter schemas with `anyOf`

Were failing to connect. This PR fixes all three issues.

## Testing

Tested with `itential-mcp` server which:
- Uses `uv --directory` command
- Takes ~4.5 seconds to initialize
- Has `anyOf` schemas in tool parameters
- Successfully connects and executes commands after these fixes